### PR TITLE
New resource "sonarqube_permissions"

### DIFF
--- a/docs/sonarqube_permissions.md
+++ b/docs/sonarqube_permissions.md
@@ -1,0 +1,53 @@
+# sonarqube_permissions
+
+Provides a Sonarqube Permissions resource. This can be used to manage global and project permissions.
+
+## Example: Set global admin permissions for a group called "my-admins"
+
+```terraform
+resource "sonarqube_permissions" "my_global_admins" {
+    group_name  = "my-admins"
+    permissions = ["admin"]
+}
+```
+
+## Example: Set project admin permissions for a group called "my-project-admins"
+
+```terraform
+resource "sonarqube_permissions" "my_project_admins" {
+    group_name  = "my-project-admins"
+    project_key = "my-project"
+    permissions = ["admin"]
+}
+```
+
+## Example: Set codeviewer & user permissions on project level for a user called "johndoe"
+
+```terraform
+resource "sonarqube_permissions" "john_project_read" {
+    login_name  = "johndoe"
+    project_key = "my-project"
+    permissions = ["codeviewer", "user"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- login_name - (Optional) The name of the user that should get the specified permissions. Changing this forces a new resource to be created. Cannot be used with `group_name`
+- group_name - (Optional) The name of the Group that should get the specified permissions. Changing this forces a new resource to be created. Cannot be used with `login_name`
+- project_key - (Optional) Specify if you want to apply project level permissions. Changing this forces a new resource to be created.
+- permissions - (Required) A list of permissions that should be applied. Changing this forces a new resource to be created.
+
+**Note:** To prevent unwanted diffs, you should sort the permissions alphabetically.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- id - A randomly generated UUID for the permission entry.
+
+## Import
+
+Importing is not supported for the `sonarqube_permissions` resource.

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.0 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
+	github.com/satori/uuid v1.2.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXq
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/satori/uuid v1.2.0 h1:6TFY4nxn5XwBx0gDfzbEMCNT6k4N/4FNIuN8RACZ0KI=
+github.com/satori/uuid v1.2.0/go.mod h1:B8HLsPLik/YNn6KKWVMDJ8nzCL8RP5WyfsnmvnAEwIU=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=

--- a/sonarqube/models.go
+++ b/sonarqube/models.go
@@ -76,7 +76,6 @@ type GetUser struct {
 	Users  []User `json:"users"`
 }
 
-// GetGroup for unmarshalling response body where users are retured
 // CreateGroupResponse for unmarshalling response body of group creation
 type CreateGroupResponse struct {
 	Group Group `json:"group"`
@@ -93,10 +92,22 @@ type Group struct {
 	Permissions  []string `json:"permissions,omitempty"`
 }
 
+// GroupPermission struct
+type GroupPermission struct {
+	Name        string   `json:"name,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+}
+
 // GetGroup for unmarshalling response body from getting group details
 type GetGroup struct {
 	Paging Paging  `json:"paging"`
 	Groups []Group `json:"groups"`
+}
+
+// GetGroupPermissions struct
+type GetGroupPermissions struct {
+	Paging Paging            `json:"paging"`
+	Groups []GroupPermission `json:"groups"`
 }
 
 // ProjectPaging used in GetProject

--- a/sonarqube/models.go
+++ b/sonarqube/models.go
@@ -62,6 +62,33 @@ type GetProject struct {
 	Components []ProjectComponents `json:"components"`
 }
 
+// User struct
+type User struct {
+	Login       string   `json:"login"`
+	Name        string   `json:"name"`
+	Email       string   `json:"email"`
+	Permissions []string `json:"permissions"`
+}
+
+// GetUser for unmarshalling response body where users are retured
+type GetUser struct {
+	Paging Paging `json:"paging"`
+	Users  []User `json:"users"`
+}
+
+// Group struct
+type Group struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Permissions []string `json:"permissions"`
+}
+
+// GetGroup for unmarshalling response body where users are retured
+type GetGroup struct {
+	Paging Paging  `json:"paging"`
+	Groups []Group `json:"groups"`
+}
+
 // ProjectPaging used in GetProject
 type Paging struct {
 	PageIndex int64 `json:"pageIndex"`

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -43,6 +43,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		// Add the resources supported by this provider to this map.
 		ResourcesMap: map[string]*schema.Resource{
+			"sonarqube_permissions":                     resourceSonarqubePermissions(),
 			"sonarqube_plugin":                          resourceSonarqubePlugin(),
 			"sonarqube_project":                         resourceSonarqubeProject(),
 			"sonarqube_qualitygate":                     resourceSonarqubeQualityGate(),

--- a/sonarqube/resource_sonarqube_permissions.go
+++ b/sonarqube/resource_sonarqube_permissions.go
@@ -179,7 +179,7 @@ func resourceSonarqubePermissionsRead(d *schema.ResourceData, m interface{}) err
 		defer resp.Body.Close()
 
 		// Decode response into struct
-		groups := GetGroup{}
+		groups := GetGroupPermissions{}
 		err = json.NewDecoder(resp.Body).Decode(&groups)
 		if err != nil {
 			return fmt.Errorf("resourceSonarqubePermissionsRead: Failed to decode json into struct: %+v", err)


### PR DESCRIPTION
This adds a new resource for managing permissions (global/project): `sonarqube_permissions`

## Example: Set global admin permissions for a group called "my-admins"

```terraform
resource "sonarqube_permissions" "my_global_admins" {
    group_name  = "my-admins"
    permissions = ["admin"]
}
```

## Example: Set project admin permissions for a group called "my-project-admins"

```terraform
resource "sonarqube_permissions" "my_project_admins" {
    group_name  = "my-project-admins"
    project_key = "my-project"
    permissions = ["admin"]
}
```

## Example: Set codeviewer & user permissions on project level for a user called "johndoe"

```terraform
resource "sonarqube_permissions" "john_project_read" {
    login_name  = "johndoe"
    project_key = "my-project"
    permissions = ["codeviewer", "user"]
}
```