### PR TITLE
Support for permission templates

### DIFF
--- a/docs/sonarqube_permission_template.md
+++ b/docs/sonarqube_permission_template.md
@@ -1,0 +1,36 @@
+# sonarqube_permission_template
+
+Provides a Sonarqube Permission template resource. This can be used to create and manage Sonarqube Permission
+templates.
+
+## Example: create a template
+
+```terraform
+resource "sonarqube_permission_template" "template" {
+    name                = "Internal-Projects"
+    description         = "These are internal projects"
+    project_key_pattern = "internal.*"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- name - (Required) The name of the Permission template to create. Changing this forces a new resource to be created.
+- description - (Optional) Description of the Template.
+- project_key_pattern - (Optional) The project key pattern. Must be a valid Java regular expression.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- id - The ID of the Permission template.
+
+## Import
+
+Templates can be imported using their ID
+
+```terraform
+terraform import sonarqube_permission_template.template ABC_defghij
+```

--- a/docs/sonarqube_permissions.md
+++ b/docs/sonarqube_permissions.md
@@ -21,6 +21,16 @@ resource "sonarqube_permissions" "my_project_admins" {
 }
 ```
 
+## Example: Set project admin permissions for a group called "my-project-admins on a permission template"
+
+```terraform
+resource "sonarqube_permissions" "internal_admins" {
+    group_name  = "my-internal-admins"
+    template_id = sonarqube_permission_template.template.id
+    permissions = ["admin"]
+}
+```
+
 ## Example: Set codeviewer & user permissions on project level for a user called "johndoe"
 
 ```terraform
@@ -37,7 +47,8 @@ The following arguments are supported:
 
 - login_name - (Optional) The name of the user that should get the specified permissions. Changing this forces a new resource to be created. Cannot be used with `group_name`
 - group_name - (Optional) The name of the Group that should get the specified permissions. Changing this forces a new resource to be created. Cannot be used with `login_name`
-- project_key - (Optional) Specify if you want to apply project level permissions. Changing this forces a new resource to be created.
+- project_key - (Optional) Specify if you want to apply project level permissions. Changing this forces a new resource to be created. Cannot be used with `template_id`
+- template_id - (Optional) Specify if you want to apply the permissions to a permission template. Changing this forces a new resource to be created. Cannot be used with `project_key`
 - permissions - (Required) A list of permissions that should be applied. Changing this forces a new resource to be created.
 
 **Note:** To prevent unwanted diffs, you should sort the permissions alphabetically.

--- a/sonarqube/models.go
+++ b/sonarqube/models.go
@@ -110,7 +110,25 @@ type GetGroupPermissions struct {
 	Groups []GroupPermission `json:"groups"`
 }
 
-// ProjectPaging used in GetProject
+// CreatePermissionTemplateResponse struct
+type CreatePermissionTemplateResponse struct {
+	PermissionTemplate PermissionTemplate `json:"permissionTemplate"`
+}
+
+// GetPermissionTemplates struct
+type GetPermissionTemplates struct {
+	Paging              Paging               `json:"paging"`
+	PermissionTemplates []PermissionTemplate `json:"permissionTemplates"`
+}
+
+// PermissionTemplate struct
+type PermissionTemplate struct {
+	ID                string `json:"id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Description       string `json:"description,omitempty"`
+	ProjectKeyPattern string `json:"projectKeyPattern,omitempty"`
+}
+
 // Paging used in /search API endpoints
 type Paging struct {
 	PageIndex int64 `json:"pageIndex"`

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 		// Add the resources supported by this provider to this map.
 		ResourcesMap: map[string]*schema.Resource{
 			"sonarqube_group":                           resourceSonarqubeGroup(),
+			"sonarqube_permission_template":             resourceSonarqubePermissionTemplate(),
 			"sonarqube_permissions":                     resourceSonarqubePermissions(),
 			"sonarqube_plugin":                          resourceSonarqubePlugin(),
 			"sonarqube_project":                         resourceSonarqubeProject(),

--- a/sonarqube/resource_sonarqube_permissions_template.go
+++ b/sonarqube/resource_sonarqube_permissions_template.go
@@ -1,0 +1,194 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// Returns the resource represented by this file.
+func resourceSonarqubePermissionTemplate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubePermissionTemplateCreate,
+		Read:   resourceSonarqubePermissionTemplateRead,
+		Update: resourceSonarqubePermissionTemplateUpdate,
+		Delete: resourceSonarqubePermissionTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubePermissionTemplateImport,
+		},
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"project_key_pattern": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceSonarqubePermissionTemplateCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/permissions/create_template"
+	sonarQubeURL.RawQuery = url.Values{
+		"name":              []string{d.Get("name").(string)},
+		"description":       []string{d.Get("description").(string)},
+		"projectKeyPattern": []string{d.Get("project_key_pattern").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		*m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubePermissionTemplateCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("Error creating Sonarqube permission template: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	permissionTemplateResponse := CreatePermissionTemplateResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&permissionTemplateResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateCreate: Failed to decode json into struct: %+v", err)
+	}
+
+	if permissionTemplateResponse.PermissionTemplate.ID != "" {
+		d.SetId(permissionTemplateResponse.PermissionTemplate.ID)
+	} else {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateCreate: Create response didn't contain an ID")
+	}
+
+	return resourceSonarqubePermissionTemplateRead(d, m)
+}
+
+func resourceSonarqubePermissionTemplateRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/permissions/search_templates"
+	sonarQubeURL.RawQuery = url.Values{
+		"q": []string{d.Get("name").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		*m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubePermissionTemplateRead",
+	)
+	if err != nil {
+		return fmt.Errorf("Error reading Sonarqube permission templates: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	permissionTemplateReadResponse := GetPermissionTemplates{}
+	err = json.NewDecoder(resp.Body).Decode(&permissionTemplateReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateRead: Failed to decode json into struct: %+v", err)
+	}
+
+	// Loop over all permission templates to see if the template we look for exists.
+	readSuccess := false
+	for _, value := range permissionTemplateReadResponse.PermissionTemplates {
+		log.Printf("[DEBUG][resourceSonarqubePermissionTemplateRead] Comparing '%s' with '%s'", d.Id(), value.ID)
+		if d.Id() == value.ID {
+			log.Printf("[DEBUG][resourceSonarqubePermissionTemplateRead] Found PermissionTemplate with ID '%s'", value.ID)
+			// If it does, set the values of that template
+			d.SetId(value.ID)
+			d.Set("name", value.Name)
+			d.Set("description", value.Description)
+			d.Set("project_key_pattern", value.ProjectKeyPattern)
+			readSuccess = true
+		}
+	}
+
+	if !readSuccess {
+		// Resource not found
+		log.Printf("[DEBUG][resourceSonarqubePermissionTemplateRead] No permission template with ID '%s' found, removing from state", d.Id())
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceSonarqubePermissionTemplateUpdate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/permissions/update_template"
+
+	rawQuery := url.Values{
+		"templateId": []string{d.Id()},
+	}
+
+	if _, ok := d.GetOk("description"); ok {
+		rawQuery.Add("description", d.Get("description").(string))
+	} else {
+		rawQuery.Add("description", "")
+	}
+
+	if _, ok := d.GetOk("project_key_pattern"); ok {
+		rawQuery.Add("projectKeyPattern", d.Get("project_key_pattern").(string))
+	} else {
+		rawQuery.Add("projectKeyPattern", "")
+	}
+
+	sonarQubeURL.RawQuery = rawQuery.Encode()
+
+	resp, err := httpRequestHelper(
+		*m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubePermissionTemplateUpdate",
+	)
+	if err != nil {
+		return fmt.Errorf("Error updating Sonarqube permission template: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return resourceSonarqubePermissionTemplateRead(d, m)
+}
+
+func resourceSonarqubePermissionTemplateDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/permissions/delete_template"
+	sonarQubeURL.RawQuery = url.Values{
+		"templateId": []string{d.Id()},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		*m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubePermissionTemplateDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("Error deleting Sonarqube permission template: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubePermissionTemplateImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceSonarqubePermissionTemplateRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
- New resource `sonarqube_permission_template`
- `sonarqube_permissions` now support `sonarqube_permission_templates`

```terraform
resource "sonarqube_permission_template" "template" {
    name                = "Internal-Projects"
    description         = "These are internal projects"
    project_key_pattern = "internal.*"
}
```

```terraform
resource "sonarqube_permissions" "internal_admins" {
    group_name  = "my-internal-admins"
    template_id = sonarqube_permission_template.template.id
    permissions = ["admin"]
}
```