### PR TITLE
New resources "sonarqube_user", "sonarqube_user_token" plus generic improvements

### DIFF
--- a/docs/sonarqube_user.md
+++ b/docs/sonarqube_user.md
@@ -1,0 +1,48 @@
+# sonarqube_user
+
+Provides a Sonarqube User resource. This can be used to manage Sonarqube Users.
+
+## Example: create a local user
+
+```terraform
+resource "sonarqube_user" "user" {
+  login_name = "terraform-test"
+  name       = "terraform-test"
+  password   = "secret-sauce37!"
+}
+```
+
+## Example: create a remote user
+
+```terraform
+resource "sonarqube_user" "remote_user" {
+  login_name = "terraform-test"
+  name       = "terraform-test"
+  email      = "terraform-test@sonarqube.com"
+  is_local   = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- login_name - (Required) The login name of the User to create. Changing this forces a new resource to be created.
+- name - (Required) The name of the User to create. Changing this forces a new resource to be created.
+- email - (Optional) The email of the User to create.
+- password - (Optional) The password of User to create. This is only used if the user is of type `local`.
+- is_local - (Optional) `True` if the User should be of type `local`. Defaults to `true`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- id - The ID of the User.
+
+## Import
+
+Users can be imported using their `login_name`:
+
+```terraform
+terraform import sonarqube_user.user terraform-test
+```

--- a/docs/sonarqube_user_token.md
+++ b/docs/sonarqube_user_token.md
@@ -1,0 +1,40 @@
+# sonarqube_user_token
+
+Provides a Sonarqube User token resource. This can be used to manage Sonarqube User tokens.
+
+## Example: create a user, user token and output the token value
+
+```terraform
+resource "sonarqube_user" "user" {
+  login_name = "terraform-test"
+  name       = "terraform-test"
+  password   = "secret-sauce37!"
+}
+
+resource "sonarqube_user_token" "token" {
+  login_name = sonarqube_user.user.login_name
+  name       = "my-token"
+}
+
+output "user_token" {
+  value = sonarqube_user_token.token.token
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- login_name - (Required) The login name of the User for which the token should be created. Changing this forces a new resource to be created.
+- name - (Required) The name of the Token to create. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- id - The ID of the Token.
+- token - The Token value.
+
+## Import
+
+Import is not supported for this resource.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-hclog v0.13.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/go-plugin v1.2.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.4.0 // indirect
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cR
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.2.2 h1:mgDpq0PkoK5gck2w4ivaMpWRHv/matdOR4xmeScmf/w=
 github.com/hashicorp/go-plugin v1.2.2/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
+github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
+github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/sonarqube/httpHelpers.go
+++ b/sonarqube/httpHelpers.go
@@ -1,15 +1,17 @@
 package sonarqube
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/go-retryablehttp"
 	log "github.com/sirupsen/logrus"
 )
 
-func httpRequestHelper(client http.Client, method string, sonarqubeURL string, expectedResponseCode int, errormsg string) (http.Response, error) {
+func httpRequestHelper(client *retryablehttp.Client, method string, sonarqubeURL string, expectedResponseCode int, errormsg string) (http.Response, error) {
 	// Prepare request
-	req, err := http.NewRequest(method, sonarqubeURL, http.NoBody)
+	req, err := retryablehttp.NewRequest(method, sonarqubeURL, http.NoBody)
 	if err != nil {
 		log.WithError(err).Error(errormsg)
 		// Returning a blank http.Response object must be wrong. What am i suppose to do here??

--- a/sonarqube/models.go
+++ b/sonarqube/models.go
@@ -64,16 +64,23 @@ type GetProject struct {
 
 // User struct
 type User struct {
-	Login       string   `json:"login"`
-	Name        string   `json:"name"`
-	Email       string   `json:"email"`
-	Permissions []string `json:"permissions"`
+	Login       string   `json:"login,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Email       string   `json:"email,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+	IsActive    bool     `json:"active,omitempty"`
+	IsLocal     bool     `json:"local,omitempty"`
 }
 
 // GetUser for unmarshalling response body where users are retured
 type GetUser struct {
 	Paging Paging `json:"paging"`
 	Users  []User `json:"users"`
+}
+
+// CreateUserResponse struct
+type CreateUserResponse struct {
+	User User `json:"user"`
 }
 
 // CreateGroupResponse for unmarshalling response body of group creation

--- a/sonarqube/models.go
+++ b/sonarqube/models.go
@@ -10,6 +10,16 @@ type Version struct {
 	PageIndex int64 `json:"pageIndex"`
 }
 
+// ErrorResponse struct
+type ErrorResponse struct {
+	Errors []ErrorMessage `json:"errors,omitempty"`
+}
+
+// ErrorMessage struct
+type ErrorMessage struct {
+	Message string `json:"msg,omitempty"`
+}
+
 // GetQualityGate for unmarshalling response body of quality gate get
 type GetQualityGate struct {
 	ID         int64                                `json:"id"`

--- a/sonarqube/models.go
+++ b/sonarqube/models.go
@@ -93,6 +93,19 @@ type CreateUserResponse struct {
 	User User `json:"user"`
 }
 
+// GetToken struct
+type GetTokens struct {
+	Login  string  `json:"login,omitempty"`
+	Tokens []Token `json:"userTokens,omitempty"`
+}
+
+// Token struct
+type Token struct {
+	Login string `json:"login,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Token string `json:"token,omitempty"`
+}
+
 // CreateGroupResponse for unmarshalling response body of group creation
 type CreateGroupResponse struct {
 	Group Group `json:"group"`

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 			"sonarqube_qualitygate":                     resourceSonarqubeQualityGate(),
 			"sonarqube_qualitygate_condition":           resourceSonarqubeQualityGateCondition(),
 			"sonarqube_qualitygate_project_association": resourceSonarqubeQualityGateProjectAssociation(),
+			"sonarqube_user":                            resourceSonarqubeUser(),
 		},
 		ConfigureFunc: configureProvider,
 	}

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -53,6 +53,7 @@ func Provider() terraform.ResourceProvider {
 			"sonarqube_qualitygate_condition":           resourceSonarqubeQualityGateCondition(),
 			"sonarqube_qualitygate_project_association": resourceSonarqubeQualityGateProjectAssociation(),
 			"sonarqube_user":                            resourceSonarqubeUser(),
+			"sonarqube_user_token":                      resourceSonarqubeUserToken(),
 		},
 		ConfigureFunc: configureProvider,
 	}

--- a/sonarqube/resource_sonarqube_group.go
+++ b/sonarqube/resource_sonarqube_group.go
@@ -94,15 +94,20 @@ func resourceSonarqubeGroupRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Loop over all groups to see if the group we need exists.
+	readSuccess := false
 	for _, value := range groupReadResponse.Groups {
 		if d.Id() == strconv.Itoa(value.ID) {
 			// If it does, set the values of that group
 			d.SetId(strconv.Itoa(value.ID))
 			d.Set("name", value.Name)
 			d.Set("description", value.Description)
-		} else {
-			d.SetId("")
+			readSuccess = true
 		}
+	}
+
+	if !readSuccess {
+		// Group not found
+		d.SetId("")
 	}
 
 	return nil

--- a/sonarqube/resource_sonarqube_group.go
+++ b/sonarqube/resource_sonarqube_group.go
@@ -45,7 +45,7 @@ func resourceSonarqubeGroupCreate(d *schema.ResourceData, m interface{}) error {
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -75,7 +75,7 @@ func resourceSonarqubeGroupRead(d *schema.ResourceData, m interface{}) error {
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"GET",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -125,7 +125,7 @@ func resourceSonarqubeGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL.RawQuery = rawQuery.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -147,7 +147,7 @@ func resourceSonarqubeGroupDelete(d *schema.ResourceData, m interface{}) error {
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_permissions.go
+++ b/sonarqube/resource_sonarqube_permissions.go
@@ -184,8 +184,8 @@ func resourceSonarqubePermissionsRead(d *schema.ResourceData, m interface{}) err
 		}
 
 		if !readSuccess {
+			// Permission not found
 			d.SetId("")
-			return fmt.Errorf("resourceSonarqubePermissionsRead: Unable to find user permissions for user: %s", loginName)
 		}
 
 	} else {

--- a/sonarqube/resource_sonarqube_permissions.go
+++ b/sonarqube/resource_sonarqube_permissions.go
@@ -106,7 +106,7 @@ func resourceSonarqubePermissionsCreate(d *schema.ResourceData, m interface{}) e
 		sonarQubeURL.RawQuery = CurrentRawQuery.Encode()
 
 		resp, err := httpRequestHelper(
-			*m.(*ProviderConfiguration).httpClient,
+			m.(*ProviderConfiguration).httpClient,
 			"POST",
 			sonarQubeURL.String(),
 			http.StatusNoContent,
@@ -154,7 +154,7 @@ func resourceSonarqubePermissionsRead(d *schema.ResourceData, m interface{}) err
 		sonarQubeURL.RawQuery = RawQuery.Encode()
 
 		resp, err := httpRequestHelper(
-			*m.(*ProviderConfiguration).httpClient,
+			m.(*ProviderConfiguration).httpClient,
 			"GET",
 			sonarQubeURL.String(),
 			http.StatusOK,
@@ -201,7 +201,7 @@ func resourceSonarqubePermissionsRead(d *schema.ResourceData, m interface{}) err
 		sonarQubeURL.RawQuery = RawQuery.Encode()
 
 		resp, err := httpRequestHelper(
-			*m.(*ProviderConfiguration).httpClient,
+			m.(*ProviderConfiguration).httpClient,
 			"GET",
 			sonarQubeURL.String(),
 			http.StatusOK,
@@ -290,7 +290,7 @@ func resourceSonarqubePermissionsDelete(d *schema.ResourceData, m interface{}) e
 		sonarQubeURL.RawQuery = CurrentRawQuery.Encode()
 
 		resp, err := httpRequestHelper(
-			*m.(*ProviderConfiguration).httpClient,
+			m.(*ProviderConfiguration).httpClient,
 			"POST",
 			sonarQubeURL.String(),
 			http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_permissions_template.go
+++ b/sonarqube/resource_sonarqube_permissions_template.go
@@ -50,7 +50,7 @@ func resourceSonarqubePermissionTemplateCreate(d *schema.ResourceData, m interfa
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -85,7 +85,7 @@ func resourceSonarqubePermissionTemplateRead(d *schema.ResourceData, m interface
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"GET",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -150,7 +150,7 @@ func resourceSonarqubePermissionTemplateUpdate(d *schema.ResourceData, m interfa
 	sonarQubeURL.RawQuery = rawQuery.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -172,7 +172,7 @@ func resourceSonarqubePermissionTemplateDelete(d *schema.ResourceData, m interfa
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_plugins.go
+++ b/sonarqube/resource_sonarqube_plugins.go
@@ -38,7 +38,7 @@ func resourceSonarqubePluginCreate(d *schema.ResourceData, m interface{}) error 
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,
@@ -58,7 +58,7 @@ func resourceSonarqubePluginRead(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL.Path = "api/plugins/installed"
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"GET",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -97,7 +97,7 @@ func resourceSonarqubePluginDelete(d *schema.ResourceData, m interface{}) error 
 
 	log.Error(sonarQubeURL.String())
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_project.go
+++ b/sonarqube/resource_sonarqube_project.go
@@ -51,7 +51,7 @@ func resourceSonarqubeProjectCreate(d *schema.ResourceData, m interface{}) error
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -81,7 +81,7 @@ func resourceSonarqubeProjectRead(d *schema.ResourceData, m interface{}) error {
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"GET",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -121,7 +121,7 @@ func resourceSonarqubeProjectDelete(d *schema.ResourceData, m interface{}) error
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_project.go
+++ b/sonarqube/resource_sonarqube_project.go
@@ -100,6 +100,7 @@ func resourceSonarqubeProjectRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Loop over all projects to see if the project we need exists.
+	readSuccess := false
 	for _, value := range projectReadResponse.Components {
 		if d.Id() == value.Key {
 			// If it does, set the values of that project
@@ -107,7 +108,13 @@ func resourceSonarqubeProjectRead(d *schema.ResourceData, m interface{}) error {
 			d.Set("name", value.Name)
 			d.Set("key", value.Key)
 			d.Set("visibility", value.Visibility)
+			readSuccess = true
 		}
+	}
+
+	if !readSuccess {
+		// Project not found
+		d.SetId("")
 	}
 
 	return nil

--- a/sonarqube/resource_sonarqube_qualitygate.go
+++ b/sonarqube/resource_sonarqube_qualitygate.go
@@ -39,7 +39,7 @@ func resourceSonarqubeQualityGateCreate(d *schema.ResourceData, m interface{}) e
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -69,7 +69,7 @@ func resourceSonarqubeQualityGateRead(d *schema.ResourceData, m interface{}) err
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"GET",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -100,7 +100,7 @@ func resourceSonarqubeQualityGateDelete(d *schema.ResourceData, m interface{}) e
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_qualitygate_condition.go
+++ b/sonarqube/resource_sonarqube_qualitygate_condition.go
@@ -52,7 +52,7 @@ func resourceSonarqubeQualityGateConditionCreate(d *schema.ResourceData, m inter
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -82,7 +82,7 @@ func resourceSonarqubeQualityGateConditionRead(d *schema.ResourceData, m interfa
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"GET",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -125,7 +125,7 @@ func resourceSonarqubeQualityGateConditionUpdate(d *schema.ResourceData, m inter
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -147,7 +147,7 @@ func resourceSonarqubeQualityGateConditionDelete(d *schema.ResourceData, m inter
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_qualitygate_project_association.go
+++ b/sonarqube/resource_sonarqube_qualitygate_project_association.go
@@ -43,7 +43,7 @@ func resourceSonarqubeQualityGateProjectAssociationCreate(d *schema.ResourceData
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,
@@ -67,7 +67,7 @@ func resourceSonarqubeQualityGateProjectAssociationRead(d *schema.ResourceData, 
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"GET",
 		sonarQubeURL.String(),
 		http.StatusOK,
@@ -108,7 +108,7 @@ func resourceSonarqubeQualityGateProjectAssociationDelete(d *schema.ResourceData
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		*m.(*ProviderConfiguration).httpClient,
+		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,

--- a/sonarqube/resource_sonarqube_user.go
+++ b/sonarqube/resource_sonarqube_user.go
@@ -1,0 +1,228 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// Returns the resource represented by this file.
+func resourceSonarqubeUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeUserCreate,
+		Read:   resourceSonarqubeUserRead,
+		Update: resourceSonarqubeUserUpdate,
+		Delete: resourceSonarqubeUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubeUserImport,
+		},
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"login_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"is_local": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceSonarqubeUserCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/users/create"
+	isLocal := d.Get("is_local").(bool)
+
+	rawQuery := url.Values{
+		"login": []string{d.Get("login_name").(string)},
+		"name":  []string{d.Get("name").(string)},
+		"local": []string{strconv.FormatBool(isLocal)},
+	}
+
+	if password, ok := d.GetOk("password"); ok {
+		rawQuery.Add("password", password.(string))
+	}
+
+	if email, ok := d.GetOk("email"); ok {
+		rawQuery.Add("email", email.(string))
+	}
+
+	sonarQubeURL.RawQuery = rawQuery.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeUserCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("Error creating Sonarqube user: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	userResponse := CreateUserResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&userResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeUserCreate: Failed to decode json into struct: %+v", err)
+	}
+
+	if userResponse.User.Login != "" {
+		d.SetId(userResponse.User.Login)
+	} else {
+		return fmt.Errorf("resourceSonarqubeUserCreate: Create response didn't contain the user login")
+	}
+
+	return resourceSonarqubeUserRead(d, m)
+}
+
+func resourceSonarqubeUserRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/users/search"
+	sonarQubeURL.RawQuery = url.Values{
+		"q": []string{d.Get("login_name").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeUserRead",
+	)
+	if err != nil {
+		return fmt.Errorf("Error reading Sonarqube user: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	userResponse := GetUser{}
+	err = json.NewDecoder(resp.Body).Decode(&userResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeUserCreate: Failed to decode json into struct: %+v", err)
+	}
+
+	// Loop over all users to see if the current user exists.
+	readSuccess := false
+	for _, value := range userResponse.Users {
+		if d.Id() == value.Login {
+			d.SetId(value.Login)
+			d.Set("login_name", value.Login)
+			d.Set("name", value.Name)
+			d.Set("email", value.Email)
+			d.Set("is_local", value.IsLocal)
+			readSuccess = true
+		}
+	}
+
+	if !readSuccess {
+		// user not found
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceSonarqubeUserUpdate(d *schema.ResourceData, m interface{}) error {
+
+	// handle default updates (api/users/update)
+	if d.HasChange("email") {
+		sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+		sonarQubeURL.Path = "api/users/update"
+		sonarQubeURL.RawQuery = url.Values{
+			"login": []string{d.Id()},
+			"email": []string{d.Get("email").(string)},
+		}.Encode()
+
+		resp, err := httpRequestHelper(
+			m.(*ProviderConfiguration).httpClient,
+			"POST",
+			sonarQubeURL.String(),
+			http.StatusOK,
+			"resourceSonarqubeUserUpdate",
+		)
+		if err != nil {
+			return fmt.Errorf("Error updating Sonarqube user: %+v", err)
+		}
+		defer resp.Body.Close()
+	}
+
+	// handle password updates (api/users/change_password)
+	if d.HasChange("password") {
+
+		sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+		sonarQubeURL.Path = "api/users/change_password"
+		sonarQubeURL.RawQuery = url.Values{
+			"login":    []string{d.Id()},
+			"password": []string{d.Get("password").(string)},
+		}.Encode()
+
+		resp, err := httpRequestHelper(
+			m.(*ProviderConfiguration).httpClient,
+			"POST",
+			sonarQubeURL.String(),
+			http.StatusNoContent,
+			"resourceSonarqubeUserUpdate",
+		)
+		if err != nil {
+			return fmt.Errorf("Error updating Sonarqube user: %+v", err)
+		}
+		defer resp.Body.Close()
+	}
+
+	return resourceSonarqubeUserRead(d, m)
+}
+
+func resourceSonarqubeUserDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/users/deactivate"
+	sonarQubeURL.RawQuery = url.Values{
+		"login": []string{d.Id()},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeUserDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("Error deleting (deactivating) Sonarqube user: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeUserImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceSonarqubeUserRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/sonarqube/resource_sonarqube_user_token.go
+++ b/sonarqube/resource_sonarqube_user_token.go
@@ -1,0 +1,157 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// Returns the resource represented by this file.
+func resourceSonarqubeUserToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeUserTokenCreate,
+		Read:   resourceSonarqubeUserTokenRead,
+		Delete: resourceSonarqubeUserTokenDelete,
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"login_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceSonarqubeUserTokenCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/user_tokens/generate"
+
+	rawQuery := url.Values{
+		"login": []string{d.Get("login_name").(string)},
+		"name":  []string{d.Get("name").(string)},
+	}
+
+	sonarQubeURL.RawQuery = rawQuery.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeUserTokenCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("Error creating Sonarqube user token: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	tokenResponse := Token{}
+	err = json.NewDecoder(resp.Body).Decode(&tokenResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeUserTokenCreate: Failed to decode json into struct: %+v", err)
+	}
+
+	if tokenResponse.Login != "" {
+		// the ID consists of the login_name and the token name (foo/bar)
+		d.SetId(fmt.Sprintf("%s/%s", d.Get("login_name").(string), d.Get("name").(string)))
+		// we set the token value here as the API wont return it later
+		if tokenResponse.Token != "" {
+			d.Set("token", tokenResponse.Token)
+		} else {
+			return fmt.Errorf("resourceSonarqubeUserTokenCreate: Create response didn't contain the token")
+		}
+	} else {
+		return fmt.Errorf("resourceSonarqubeUserTokenCreate: Create response didn't contain the user login")
+	}
+
+	return resourceSonarqubeUserTokenRead(d, m)
+}
+
+func resourceSonarqubeUserTokenRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/user_tokens/search"
+	sonarQubeURL.RawQuery = url.Values{
+		"login": []string{d.Get("login_name").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeUserTokenRead",
+	)
+	if err != nil {
+		return fmt.Errorf("Error reading Sonarqube user tokens: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	getTokensResponse := GetTokens{}
+	err = json.NewDecoder(resp.Body).Decode(&getTokensResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeUserTokenCreate: Failed to decode json into struct: %+v", err)
+	}
+
+	// Loop over all user token to see if the current token exists.
+	readSuccess := false
+	if getTokensResponse.Tokens != nil {
+		for _, value := range getTokensResponse.Tokens {
+			if d.Get("name").(string) == value.Name {
+				d.SetId(fmt.Sprintf("%s/%s", d.Get("login_name").(string), d.Get("name").(string)))
+				d.Set("login_name", getTokensResponse.Login)
+				d.Set("name", value.Name)
+				readSuccess = true
+			}
+		}
+	} else {
+		// the user has no tokens
+		d.SetId("")
+	}
+
+	if !readSuccess {
+		// Token not found
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceSonarqubeUserTokenDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = "api/user_tokens/revoke"
+	sonarQubeURL.RawQuery = url.Values{
+		"login": []string{d.Get("login_name").(string)},
+		"name":  []string{d.Get("name").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeUserTokenDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("Error deleting Sonarqube user token: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}


### PR DESCRIPTION
# New resources

- `sonarqube_user`
- `sonarqube_user_token`

# Additional changes/fixes

- Introduces [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp), which replaces the default http client:

> retryablehttp performs automatic retries under certain conditions. Mainly, if an error is returned by the client (connection errors, etc.), or if a 500-range response code is received (except 501), then a retry is invoked after a wait period. Otherwise, the response is returned and left to the caller to interpret.

- Return API error message in case the response status code didn't match the expected value

- This PR adds a missing checks to detect missing resources