### PR TITLE
add provider attribute for specifying sonarqube version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,3 +17,4 @@ The following arguments are supported:
 - user - (Required) Sonarqube user. This can also be set via the SONARQUBE_USER environment variable.
 - pass - (Required) Sonarqube pass. This can also be set via the SONARQUBE_PASS environment variable.
 - host - (Required) Sonarqube url. This can be also be set via the SONARQUBE_HOST environment variable.
+- version - (Optional) The version of Sonarqube. When specified, the provider will avoid requesting this from the server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.  

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,4 @@ The following arguments are supported:
 - user - (Required) Sonarqube user. This can also be set via the SONARQUBE_USER environment variable.
 - pass - (Required) Sonarqube pass. This can also be set via the SONARQUBE_PASS environment variable.
 - host - (Required) Sonarqube url. This can be also be set via the SONARQUBE_HOST environment variable.
-- version - (Optional) The version of Sonarqube. When specified, the provider will avoid requesting this from the server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.  
+- installed_version - (Optional) The version of the Sonarqube server. When specified, the provider will avoid requesting this from the server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.  

--- a/docs/resources/sonarqube_webhook.md
+++ b/docs/resources/sonarqube_webhook.md
@@ -1,4 +1,4 @@
-# sonarqube_user
+# sonarqube_webhook
 
 Provides a Sonarqube Webhook resource. This can be used to manage Sonarqube webhooks.
 

--- a/docs/resources/sonarqube_webhook.md
+++ b/docs/resources/sonarqube_webhook.md
@@ -1,0 +1,35 @@
+# sonarqube_user
+
+Provides a Sonarqube Webhook resource. This can be used to manage Sonarqube webhooks.
+
+## Example: create a webhook
+
+```terraform
+resource "sonarqube_webhook" "webhook" {
+  name = "terraform-webhook"
+  url  = "https://my-webhook-destination.example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- name - (Required) The name of the webhook to create. This will be displayed in the Sonarqube administration console.
+- url - (Required) The URL to send event payloads to. This must begin with either `https://` or `http://`.
+- secret 0 (Optional) The secret to send with the event payload.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- id - The ID (key) of the webhook.
+
+## Import
+
+Webhooks can be imported using their ID (key):
+
+```bash
+terraform import sonarqube_webhook.webhook AXnN9NuxdWLvsEEPOr2g
+```

--- a/docs/resources/sonarqube_webhook.md
+++ b/docs/resources/sonarqube_webhook.md
@@ -17,7 +17,7 @@ The following arguments are supported:
 
 - name - (Required) The name of the webhook to create. This will be displayed in the Sonarqube administration console.
 - url - (Required) The URL to send event payloads to. This must begin with either `https://` or `http://`.
-- secret 0 (Optional) The secret to send with the event payload.
+- secret - (Optional) The secret to send with the event payload.
 
 
 ## Attributes Reference

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -100,12 +100,11 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		return nil, fmt.Errorf("Unsupported version of sonarqube. Minimum supported version is %+v. Running version is %+v", minimumVersion, installedVersion)
 	}
 
-	config := &ProviderConfiguration{
+	return &ProviderConfiguration{
 		httpClient:       client,
 		sonarQubeURL:     sonarQubeURL,
 		sonarQubeVersion: installedVersion,
-	}
-	return config, nil
+	}, nil
 }
 
 func sonarqubeHealth(client *retryablehttp.Client, sonarqube url.URL) (*version.Version, error) {


### PR DESCRIPTION
I was running into an issue when using Terraform to install a Sonarqube server (via the `helm_release` resource), then using this provider to configure it.  The problem with this is that the provider initialization process fetches the version from the Sonarqube server, and this fails during the first run of `terraform apply` because the Sonarqube server is not running yet.

I added this provider attribute so users could specify the version up front, which avoids this initial request.  This allows my Terraform code to both install the Sonarqube server, and use this provider to configure it (all with one run of `terraform apply`).

There is probably a better way to do this, but this works for now.  I also backfilled some missing docs from my last PR.