### PR TITLE
add tls_insecure_skip_verify provider attribute

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,4 +25,5 @@ The following arguments are supported:
 - user - (Required) Sonarqube user. This can also be set via the SONARQUBE_USER environment variable.
 - pass - (Required) Sonarqube pass. This can also be set via the SONARQUBE_PASS environment variable.
 - host - (Required) Sonarqube url. This can be also be set via the SONARQUBE_HOST environment variable.
-- installed_version - (Optional) The version of the Sonarqube server. When specified, the provider will avoid requesting this from the server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.  
+- installed_version - (Optional) The version of the Sonarqube server. When specified, the provider will avoid requesting this from the server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.
+- tls_insecure_skip_verify - (Optional) Allows ignoring insecure certificates when set to true. Defaults to false. Disabling TLS verification is dangerous and should only be done for local testing.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.3.0


### PR DESCRIPTION
this option allows you to run terraform against a sonarqube instance with an invalid certificate.