### PR TITLE
Add function for updating project's visibility

### DIFF
--- a/sonarqube/resource_sonarqube_project_test.go
+++ b/sonarqube/resource_sonarqube_project_test.go
@@ -72,3 +72,29 @@ func TestAccSonarqubeProjectBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccSonarqubeProjectVisibilityUpdate(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_project." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeProjectBasicConfig(rnd, "testAccSonarqubeProject", "testAccSonarqubeProject", "public"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeProject"),
+					resource.TestCheckResourceAttr(name, "visibility", "public"),
+				),
+			},
+			{
+				Config: testAccSonarqubeProjectBasicConfig(rnd, "testAccSonarqubeProject", "testAccSonarqubeProject", "private"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeProject"),
+					resource.TestCheckResourceAttr(name, "visibility", "private"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Added a new function "resourceSonarqubeProjectUpdate" which uses Sonarqube's api/projects/update_visibility API for updating project's visibility setting.

This might be the first time I'm writing (copy/pasting) Go so basic mistakes are expected. All comments are appreciated.

Fixes https://github.com/jdamata/terraform-provider-sonarqube/issues/71 