### PR TITLE
Let provider authenticate using user token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Provider configuration
 
-The sonarqube provider is used to configure sonarqube. The provider needs to be configured with a url, user and password.
+The sonarqube provider is used to configure sonarqube. The provider needs to be configured with a url, and either with user and password or token.
 
-## Example Usage
+## Example: Authenticate with username and password
 ```terraform
 terraform {
   required_providers {
@@ -19,11 +19,28 @@ provider "sonarqube" {
 }
 ```
 
+## Example: Authenticate with token
+```terraform
+terraform {
+  required_providers {
+    sonarqube = {
+      source = "jdamata/sonarqube"
+    }
+  }
+}
+
+provider "sonarqube" {
+    token  = "d4at55a6f7r199bd707h39625685510880gbf7ff"
+    host   = "http://127.0.0.1:9000"
+}
+```
+
 ## Argument Reference
 The following arguments are supported:
 
-- user - (Required) Sonarqube user. This can also be set via the SONARQUBE_USER environment variable.
-- pass - (Required) Sonarqube pass. This can also be set via the SONARQUBE_PASS environment variable.
+- user - (Optional) Sonarqube user. This can also be set via the SONARQUBE_USER environment variable.
+- pass - (Optional) Sonarqube pass. This can also be set via the SONARQUBE_PASS environment variable.
+- token - (Optional) Sonarqube token. This can also be set via the SONARQUBE_TOKEN environment variable.
 - host - (Required) Sonarqube url. This can be also be set via the SONARQUBE_HOST environment variable.
 - installed_version - (Optional) The version of the Sonarqube server. When specified, the provider will avoid requesting this from the server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.
 - tls_insecure_skip_verify - (Optional) Allows ignoring insecure certificates when set to true. Defaults to false. Disabling TLS verification is dangerous and should only be done for local testing.

--- a/sonarqube/provider_test.go
+++ b/sonarqube/provider_test.go
@@ -34,8 +34,10 @@ func TestProvider_impl(t *testing.T) {
 
 func testAccPreCheck(t *testing.T) {
 	testSonarHost(t)
-	testSonarUser(t)
-	testSonarPass(t)
+	if v := os.Getenv("SONAR_TOKEN"); v == "" {
+		testSonarUser(t)
+		testSonarPass(t)
+	}
 }
 
 func testSonarUser(t *testing.T) {


### PR DESCRIPTION
`ExactlyOneOf: []string{"pass", "token"},` ensures that either one has to be provided even though both are set to `optional`.

Not sure how to automate testing for this. Can we change the provider config on the fly during a testrun?