### PR TITLE
Add support for settings that accept multiple values

### DIFF
--- a/docs/resources/sonarqube_settings.md
+++ b/docs/resources/sonarqube_settings.md
@@ -2,23 +2,49 @@
 
 Provides a Sonarqube Settings resource. This can be used to manage Sonarqube settings.
 
-## Example: create a setting
+## Example: create a setting with a single value
 
 ```terraform
-resource "sonarqube_setting" "setting" {
+resource "sonarqube_setting" "single_setting" {
   key   = "sonar.demo"
   value = "sonarqube@example.org"
 }
 
 ```
 
+## Example: create a setting with multiple values
+```terraform
+resource "sonarqube_setting" "multi_value_setting" {
+  key   = "sonar.global.exclusions"
+  values = ["foo", "bar/**/*.*"]
+}
+```
+## Example: create a setting with multiple field values
+```terraform
+resource "sonarqube_setting" "multi_field_setting" {
+  key   = "sonar.issue.ignore.multicriteria"
+  field_values = [
+    {
+      "ruleKey" : "foo",
+      "resourceKey" : "bar"
+    },
+    {
+      "ruleKey" : "foo2",
+      "resourceKey" : "bar2"
+    }
+  ]
+}
+```
 ## Argument Reference
 
 The following arguments are supported
 
 - key - (Required) Setting key
-- value - (Required) Setting value
+- value - (Optional) Single valued setting value
+- values - (Optional) Multi-valued setting values
+- field_values - (Optional) Multi-field setting values
 
+One of value, values, field_values _must_ be supplied
 ## Attribute Reference
 
 The following attributes are exported:

--- a/sonarqube/helper_test.go
+++ b/sonarqube/helper_test.go
@@ -1,6 +1,7 @@
 package sonarqube
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -15,4 +16,15 @@ func generateHCLList(s []string) string {
 	semiformat := fmt.Sprintf("%+q", s)      // Turn the slice into a string that looks like ["one" "two" "three"]
 	tokens := strings.Split(semiformat, " ") // Split this string by spaces
 	return strings.Join(tokens, ", ")        // Join the Slice together (that was split by spaces) with commas
+}
+// Turns the map into a string that looks like {"one": "two", "three": "four"}
+func generateHCLMap(m map[string]string) string {
+	b := new(bytes.Buffer)
+	fmt.Fprintf(b, "{")
+	for key, value := range m {
+		fmt.Fprintf(b, "\"%s\":\"%s\", ", key, value)
+	}
+	b.Truncate(b.Len() - 2)
+	fmt.Fprintf(b, "}")
+	return b.String()
 }

--- a/sonarqube/resource_sonarqube_setting_test.go
+++ b/sonarqube/resource_sonarqube_setting_test.go
@@ -26,6 +26,22 @@ func testAccSonarqubeSettingBasicConfig(rnd string, key string, value string) st
 		}`, rnd, key, value)
 }
 
+func testAccSonarqubeSettingConfigMultipleValues(rnd string, key string, values []string) string {
+	formattedValues := generateHCLList(values)
+	return fmt.Sprintf(`
+		resource "sonarqube_setting" "%[1]s" {
+			key = "%[2]s"
+			values = %[3]s
+		}`, rnd, key, formattedValues)
+}
+func testAccSonarqubeSettingConfigMultipleFields(rnd string, key string, fields map[string]string) string {
+	formattedFields := generateHCLMap(fields)
+	return fmt.Sprintf(`
+		resource "sonarqube_setting" "%[1]s" {
+			key = "%[2]s"
+			field_values = [%[3]s]
+		}`, rnd, key, formattedFields)
+}
 func TestAccSonarqubeSettingBasic(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "sonarqube_setting." + rnd
@@ -48,6 +64,63 @@ func TestAccSonarqubeSettingBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "key", "sonar.demo"),
 					resource.TestCheckResourceAttr(name, "value", "sonarqube@example.org"),
+				),
+			},
+		},
+	})
+}
+func TestAccSonarqubeSettingMultipleValues(t *testing.T) {
+	key := "sonar.global.exclusions" // Needs to be a setting that accepts multiple values
+	rnd := generateRandomResourceName()
+	name := "sonarqube_setting." + rnd
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeSettingConfigMultipleValues(rnd, key, []string{"foo", "bar"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", key),
+					resource.TestCheckTypeSetElemAttr(name, "values.*", "foo"),
+					resource.TestCheckTypeSetElemAttr(name, "values.*", "bar"),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", key),
+					resource.TestCheckTypeSetElemAttr(name, "values.*", "foo"),
+					resource.TestCheckTypeSetElemAttr(name, "values.*", "bar"),
+				),
+			},
+		},
+	})
+}
+func TestAccSonarqubeSettingMultipleFields(t *testing.T) {
+	key := "sonar.issue.ignore.multicriteria" // Needs to be a setting that accepts multiple fields
+	rnd := generateRandomResourceName()
+	name := "sonarqube_setting." + rnd
+	expected := map[string]string{"ruleKey": "foo", "resourceKey": "bar"}
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeSettingConfigMultipleFields(rnd, key, expected),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", key),
+					resource.TestCheckTypeSetElemNestedAttrs(name, "field_values.*", expected),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", key),
+					resource.TestCheckTypeSetElemNestedAttrs(name, "field_values.*", expected),
 				),
 			},
 		},


### PR DESCRIPTION
Addresses #103 

Implements support for both `values` and `fieldValues` settings.
These should all work with this change:
```terraform
resource "sonarqube_setting" "email_from" {
  key   = "email.from"
  value = "fred@fish.com1"
}

resource "sonarqube_setting" "analysis_scope_source_exclusions" {
  key    = "sonar.global.exclusions"
  values = ["foo/**/*.*", "./bar"]
}

resource "sonarqube_setting" "multicriteria" {
  key = "sonar.issue.ignore.multicriteria"
  field_values = [
    {
      "ruleKey" : "foo",
      "resourceKey" : "bar"
    },
    {
      "ruleKey" : "foo2",
      "resourceKey" : "bar2"
    }
  ]
}
```
