### PR TITLE
docs: add comment on permission template name

### DIFF
--- a/docs/resources/sonarqube_permission_template.md
+++ b/docs/resources/sonarqube_permission_template.md
@@ -17,7 +17,7 @@ resource "sonarqube_permission_template" "template" {
 
 The following arguments are supported:
 
-- name - (Required) The name of the Permission template to create. Do not use names with `/`. If needed, use `replace(var.permission_template_name, "/", "_")`. Changing this forces a new resource to be created. 
+- name - (Required) The name of the Permission template to create. Do not use names with `/`. If needed, use `replace(var.permission_template_name, "/", "_")`. Changing this forces a new resource to be created.
 - description - (Optional) Description of the Template.
 - project_key_pattern - (Optional) The project key pattern. Must be a valid Java regular expression.
 - default - (Optional) Set the template as the default. This can only be set for one template.

--- a/docs/resources/sonarqube_permission_template.md
+++ b/docs/resources/sonarqube_permission_template.md
@@ -17,7 +17,7 @@ resource "sonarqube_permission_template" "template" {
 
 The following arguments are supported:
 
-- name - (Required) The name of the Permission template to create. Changing this forces a new resource to be created.
+- name - (Required) The name of the Permission template to create. Do not use names with `/`. If needed, use `replace(var.permission_template_name, "/", "_")`. Changing this forces a new resource to be created. 
 - description - (Optional) Description of the Template.
 - project_key_pattern - (Optional) The project key pattern. Must be a valid Java regular expression.
 - default - (Optional) Set the template as the default. This can only be set for one template.


### PR DESCRIPTION
- Add notes about permission template name 


---

If permission template rule name has `/`, API is not responding correctly to GET request with the permission template name and terraform appy/plan fails dramatically. 