### PR TITLE
Option to anonymize users on destroy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,9 +38,13 @@ provider "sonarqube" {
 ## Argument Reference
 The following arguments are supported:
 
-- user - (Optional) Sonarqube user. This can also be set via the SONARQUBE_USER environment variable.
-- pass - (Optional) Sonarqube pass. This can also be set via the SONARQUBE_PASS environment variable.
-- token - (Optional) Sonarqube token. This can also be set via the SONARQUBE_TOKEN environment variable.
-- host - (Required) Sonarqube url. This can be also be set via the SONARQUBE_HOST environment variable.
-- installed_version - (Optional) The version of the Sonarqube server. When specified, the provider will avoid requesting this from the server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.
-- tls_insecure_skip_verify - (Optional) Allows ignoring insecure certificates when set to true. Defaults to false. Disabling TLS verification is dangerous and should only be done for local testing.
+- `user` - (Optional) Sonarqube user. This can also be set via the `SONARQUBE_USER` environment variable.
+- `pass` - (Optional) Sonarqube pass. This can also be set via the `SONARQUBE_PASS` environment variable.
+- `token` - (Optional) Sonarqube token. This can also be set via the `SONARQUBE_TOKEN` environment variable.
+- `host` - (Required) Sonarqube url. This can be also be set via the `SONARQUBE_HOST` environment variable.
+- `installed_version` - (Optional) The version of the Sonarqube server. When specified, the provider will avoid requesting this from the 
+  server during the initialization process. This can be helpful when using the same Terraform code to install Sonarqube and configure it.
+- `tls_insecure_skip_verify` - (Optional) Allows ignoring insecure certificates when set to true. Defaults to false. Disabling TLS verification 
+  is dangerous and should only be done for local testing.
+- `anonymize_user_on_delete` - (Optional) Allows anonymizing users on destroy. Requires Sonarqube version >= `9.7`. This can be helpful 
+  to comply with regulations like [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation).

--- a/docs/resources/sonarqube_user.md
+++ b/docs/resources/sonarqube_user.md
@@ -2,6 +2,10 @@
 
 Provides a Sonarqube User resource. This can be used to manage Sonarqube Users.
 
+**Note**: By default Sonarqube only *deactivates* a user on `destroy` but keeps its personal data in the database. Since release `9.7` it
+is possible to automatically anonymize the data. This can be helpful to comply with regulations like [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation).
+This behaviour can be activated with the `anonymize_user_on_delete` flag on the `provider` configuration.
+
 ## Example: create a local user
 
 ```terraform

--- a/sonarqube/resource_sonarqube_user.go
+++ b/sonarqube/resource_sonarqube_user.go
@@ -218,7 +218,8 @@ func resourceSonarqubeUserDelete(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/users/deactivate"
 	sonarQubeURL.RawQuery = url.Values{
-		"login": []string{d.Id()},
+		"login":     []string{d.Id()},
+		"anonymize": []string{strconv.FormatBool(m.(*ProviderConfiguration).sonarQubeAnonymizeUsers)},
 	}.Encode()
 
 	resp, err := httpRequestHelper(


### PR DESCRIPTION
This adds support for the newly introduced option to anonymize user data when destroying a `sonarqube_user` resource. This will be helpful if you need to comply with regulations like [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) in the EU.

I think the best way to enable this with the option to keep the existing behaviour is with a flag in the provider configuration.