### PR TITLE
Hotfix : Github Binding

### DIFF
--- a/docs/resources/sonarqube_github_binding.md
+++ b/docs/resources/sonarqube_github_binding.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 - alm_setting - (Required) - GitHub ALM setting key
 - monorepo - (Optional) - Is this project part of a monorepo. Default value: false
 - project - (Required) - Project key
-- repository - (Required) - GitHub Repository in full name format. Maximum length: 256
+- repository - (Required) - The full name of your GitHub repository, including the organization, case-sensitive. Maximum length: 256
 - summary_comment_enabled - (optional) - Enable/disable summary in PR discussion tab. Default value: true
 
 ## Attributes Reference

--- a/docs/resources/sonarqube_github_binding.md
+++ b/docs/resources/sonarqube_github_binding.md
@@ -23,8 +23,8 @@ resource "sonarqube_project" "main" {
 }
 resource "sonarqube_github_binding" "github-binding" {
   alm_setting = sonarqube_alm_github.github-alm.key
-  project    = sonarqube_project.main.project
-  repository = "myrepo"
+  project    = "my_project"
+  repository = "myorg/myrepo"
 }
 ```
 
@@ -35,7 +35,7 @@ The following arguments are supported:
 - alm_setting - (Required) - GitHub ALM setting key
 - monorepo - (Optional) - Is this project part of a monorepo. Default value: false
 - project - (Required) - Project key
-- repository - (Required) - GitHub Repository. Maximum length: 256
+- repository - (Required) - GitHub Repository in full name format. Maximum length: 256
 - summary_comment_enabled - (optional) - Enable/disable summary in PR discussion tab. Default value: true
 
 ## Attributes Reference

--- a/docs/resources/sonarqube_project_main_branch.md
+++ b/docs/resources/sonarqube_project_main_branch.md
@@ -10,7 +10,7 @@ resource "sonarqube_project" "main" {
 }
 resource "sonarqube_project_main_branch" "mybranch" {
   name    = "release"
-  project = sonarqube_project.main.project
+  project = "my_project"
 }
 ```
 

--- a/sonarqube/resource_sonarqube_github_binding.go
+++ b/sonarqube/resource_sonarqube_github_binding.go
@@ -18,7 +18,7 @@ type GetBinding struct {
 	Repository            string `json:"repository"`
 	URL                   string `json:"url"`
 	SummaryCommentEnabled bool   `json:"summaryCommentEnabled"`
-	Monorepo              bool	 `json:"monorepo"`
+	Monorepo              bool   `json:"monorepo"`
 }
 
 // Returns the resource represented by this file.
@@ -94,7 +94,7 @@ func resourceSonarqubeGithubBindingCreate(d *schema.ResourceData, m interface{})
 }
 
 func resourceSonarqubeGithubBindingRead(d *schema.ResourceData, m interface{}) error {
-	idSlice := strings.Split(d.Id(), "/")
+	idSlice := strings.SplitN(d.Id(), "/", 2)
 	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/get_binding"
 	sonarQubeURL.RawQuery = url.Values{
@@ -125,7 +125,7 @@ func resourceSonarqubeGithubBindingRead(d *schema.ResourceData, m interface{}) e
 		d.Set("repository", idSlice[1])
 		d.Set("alm_setting", BindingReadResponse.Key)
 		d.Set("monorepo", strconv.FormatBool(BindingReadResponse.Monorepo))
-		d.Set("summary_comment_enabled",  strconv.FormatBool(BindingReadResponse.SummaryCommentEnabled))
+		d.Set("summary_comment_enabled", strconv.FormatBool(BindingReadResponse.SummaryCommentEnabled))
 
 		return nil
 	}

--- a/sonarqube/resource_sonarqube_github_binding_test.go
+++ b/sonarqube/resource_sonarqube_github_binding_test.go
@@ -19,7 +19,7 @@ func testSweepSonarqubeGithubBinding(r string) error {
 	return nil
 }
 
-func testAccSonarqubeGithubBindingName(rnd string, projName string, almSetting string) string {
+func testAccSonarqubeGithubBindingName(rnd string, projName string, almSetting string, repoName string) string {
 	return fmt.Sprintf(`
 		
 		resource "sonarqube_alm_github" "%[1]s" {
@@ -41,10 +41,10 @@ func testAccSonarqubeGithubBindingName(rnd string, projName string, almSetting s
 			alm_setting   = "%[3]s"
 			monorepo     = "false"
 			project = sonarqube_project.%[1]s.project
-			repository   = sonarqube_project.%[1]s.project
+			repository   = "%[4]s"
 			summary_comment_enabled = "true"
 		    depends_on = [sonarqube_alm_github.%[1]s]
-		}`, rnd, projName, almSetting)
+		}`, rnd, projName, almSetting, repoName)
 }
 
 func TestAccSonarqubeGithubBindingName(t *testing.T) {
@@ -56,11 +56,12 @@ func TestAccSonarqubeGithubBindingName(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSonarqubeGithubBindingName(rnd, "testAccSonarqubeGithubBindingName", "github"),
+				Config: testAccSonarqubeGithubBindingName(rnd, "testAccSonarqubeGithubBindingName", "github", "testAccSonarqubeGithubBindingName"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeGithubBindingName"),
 					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeGithubBindingName"),
 					resource.TestCheckResourceAttr(name, "alm_setting", "github"),
+					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeGithubBindingName"),
 				),
 			},
 			{
@@ -74,7 +75,7 @@ func TestAccSonarqubeGithubBindingName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSonarqubeGithubBindingName(rnd, "testAccSonarqubeGithubBindingName", "githubb"),
+				Config: testAccSonarqubeGithubBindingName(rnd, "testAccSonarqubeGithubBindingName", "githubb", "testAccSonarqubeGithubBindingName"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeGithubBindingName"),
 					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeGithubBindingName"),
@@ -89,6 +90,24 @@ func TestAccSonarqubeGithubBindingName(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeGithubBindingName"),
 					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeGithubBindingName"),
 					resource.TestCheckResourceAttr(name, "alm_setting", "githubb"),
+				),
+			},
+			{
+				Config: testAccSonarqubeGithubBindingName(rnd, "testAccSonarqubeGithubBindingName", "GitHub", "org/testAccSonarqubeGithubBindingName"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeGithubBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "org/testAccSonarqubeGithubBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "GitHub"),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeGithubBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "org/testAccSonarqubeGithubBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "GitHub"),
 				),
 			},
 		},


### PR DESCRIPTION
I found a bug in the GitHub binding where if you use a full name with the structure such as "jdamata/terraform-provider-sonarqube" , the id would be project/jdamata/terraform-provider-sonarqube , but because we split on / it would be three strings which causes the project to fail. Ive corrected this and also added a test inside the github binding to test org/testAccSonarqubeGithubBindingName so that we can support full name structure 