### PR TITLE
Resource to manage group members

### DIFF
--- a/docs/resources/sonarqube_group_member.md
+++ b/docs/resources/sonarqube_group_member.md
@@ -1,0 +1,44 @@
+# sonarqube_group_member
+
+Provides a Sonarqube Group Member resource. This can be used to add or remove user to or from Sonarqube Groups.
+
+## Example: add a user to a group
+
+```terraform
+resource "sonarqube_user" "user" {
+    login_name = "terraform-test"
+    name       = "terraform-test"
+    password   = "secret-sauce37!"
+}
+
+resource "sonarqube_group" "project_users" {
+    name        = "Project-Users"
+    description = "This is a group"
+}
+
+resource "sonarqube_group_member" "project_users_member" {
+    name       = sonarqube_group.project_users.name
+    login_name = sonarqube_user.user.login_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Required) The name of the Group to add a member to. Changing this forces a new resource to be created.
+- `login_name` - (Required) The `login_name` of the User to add as a member. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- id - The ID of the Group Membership.
+
+## Import
+
+Group Members can be imported using their ID (`<name>[<login_name>]`):
+
+```terraform
+terraform import sonarqube_group_member.member group[user]
+```

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -67,6 +67,7 @@ func Provider() *schema.Provider {
 		// Add the resources supported by this provider to this map.
 		ResourcesMap: map[string]*schema.Resource{
 			"sonarqube_group":                              resourceSonarqubeGroup(),
+			"sonarqube_group_member":                       resourceSonarqubeGroupMember(),
 			"sonarqube_permission_template":                resourceSonarqubePermissionTemplate(),
 			"sonarqube_permissions":                        resourceSonarqubePermissions(),
 			"sonarqube_plugin":                             resourceSonarqubePlugin(),

--- a/sonarqube/resource_sonarqube_group_member.go
+++ b/sonarqube/resource_sonarqube_group_member.go
@@ -1,0 +1,210 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// GroupMember struct
+type GroupMember struct {
+	LoginName string `json:"login,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+// GetGroupMembersResponse for unmarshalling response body of group creation
+type GetGroupMembersResponse struct {
+	Paging  Paging        `json:"paging"`
+	Members []GroupMember `json:"users"`
+}
+
+// Returns the resource represented by this file.
+func resourceSonarqubeGroupMember() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeGroupMemberCreate,
+		Read:   resourceSonarqubeGroupMemberRead,
+		Delete: resourceSonarqubeGroupMemberDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubeGroupMemberImport,
+		},
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"login_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceSonarqubeGroupMemberCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_groups/add_user"
+	sonarQubeURL.RawQuery = url.Values{
+		"name":  []string{d.Get("name").(string)},
+		"login": []string{d.Get("login_name").(string)},
+	}.Encode()
+
+	groupMembershipId := createGroupMembershipId(d.Get("name").(string), d.Get("login_name").(string))
+
+	// We need to check if a user is already a member in advance because SQ does not report this conflict in the add_user API call:
+	exists, _ := checkGroupMemberExists(d.Get("name").(string), d.Get("login_name").(string), m)
+	if exists {
+		return fmt.Errorf("resourceSonarqubeGroupMemberCreate: Group membership already exists: %+v", groupMembershipId)
+	}
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeGroupMemberCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("error adding user to Sonarqube group: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	d.SetId(groupMembershipId)
+
+	return resourceSonarqubeGroupMemberRead(d, m)
+}
+
+func resourceSonarqubeGroupMemberRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_groups/users"
+	sonarQubeURL.RawQuery = url.Values{
+		"name": []string{d.Get("name").(string)},
+		"q":    []string{d.Get("login_name").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeGroupMemberRead",
+	)
+	if err != nil {
+		return fmt.Errorf("error reading Sonarqube group members: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	readSuccess := false
+	// Decode response into struct
+	groupMemberReadResponse := GetGroupMembersResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&groupMemberReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeGroupRead: Failed to decode json into struct: %+v", err)
+	}
+	// Loop over all returned members to see if the member we need exists.
+	for _, value := range groupMemberReadResponse.Members {
+		if d.Get("login_name").(string) == value.LoginName {
+			// If it does, set the values of that group membership
+			d.SetId(createGroupMembershipId(d.Get("name").(string), d.Get("login_name").(string)))
+			d.Set("name", d.Get("name").(string))
+			d.Set("login_name", value.LoginName)
+			readSuccess = true
+		}
+	}
+
+	if !readSuccess {
+		// Group member not found
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceSonarqubeGroupMemberDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_groups/remove_user"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"name":  []string{d.Get("name").(string)},
+		"login": []string{d.Get("login_name").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeGroupMemberDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("error deleting Sonarqube group member: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeGroupMemberImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	rgx := regexp.MustCompile(`(.*?)\[(.*?)\]`)
+	rs := rgx.FindStringSubmatch(d.Id())
+	groupName := rs[1]
+	loginName := rs[2]
+
+	exists, _ := checkGroupMemberExists(groupName, loginName, m)
+	if exists {
+		d.Set("name", groupName)
+		d.Set("login_name", loginName)
+
+		return []*schema.ResourceData{d}, nil
+	} else {
+		return nil, fmt.Errorf("User \"%+v\" not a member of group \"%+v\"", loginName, groupName)
+	}
+}
+
+func checkGroupMemberExists(groupName string, loginName string, m interface{}) (bool, error) {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_groups/users"
+	sonarQubeURL.RawQuery = url.Values{
+		"name": []string{groupName},
+		"q":    []string{loginName},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"checkGroupMemberExists",
+	)
+	if err != nil {
+		return false, fmt.Errorf("error reading Sonarqube group members: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	groupMemberReadResponse := GetGroupMembersResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&groupMemberReadResponse)
+	if err != nil {
+		return false, fmt.Errorf("checkGroupMemberExists: Failed to decode json into struct: %+v", err)
+	}
+	// Loop over all returned members to see if the member we need exists.
+	for _, value := range groupMemberReadResponse.Members {
+		if loginName == value.LoginName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func createGroupMembershipId(groupName string, loginName string) string {
+	return groupName + "[" + loginName + "]"
+}

--- a/sonarqube/resource_sonarqube_group_member_test.go
+++ b/sonarqube/resource_sonarqube_group_member_test.go
@@ -1,0 +1,59 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("sonarqube_group_member", &resource.Sweeper{
+		Name: "sonarqube_group_member",
+		F:    testSweepSonarqubeGroupMemberSweeper,
+	})
+}
+
+// TODO: implement sweeper to clean up groups: https://www.terraform.io/docs/extend/testing/acceptance-tests/sweepers.html
+func testSweepSonarqubeGroupMemberSweeper(r string) error {
+	return nil
+}
+
+func testAccSonarqubeGroupMemberBasicConfig(rnd string, groupName string, loginName string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_user" "%[1]s_user" {
+			login_name = "%[3]s"
+			name       = "Test User"
+			email      = "terraform-test@sonarqube.com"
+			password   = "secret-sauce!"
+		}
+
+		resource "sonarqube_group" "%[1]s_group" {
+			name        = "%[2]s"
+		}
+
+		resource "sonarqube_group_member" "%[1]s" {
+			name       = sonarqube_group.%[1]s_group.name
+			login_name = sonarqube_user.%[1]s_user.login_name
+		}
+		`, rnd, groupName, loginName)
+}
+
+func TestAccSonarqubeGroupMemberBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_group_member." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeGroupMemberBasicConfig(rnd, "testAccSonarqubeGroup", "testAccSonarqubeUser"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeGroup"),
+					resource.TestCheckResourceAttr(name, "login_name", "testAccSonarqubeUser"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
My next contribution adds support for managing group members. I know there are different ways to model this but I think this one (separate resource, not modifying `sonarqube_group`) is the most simple one.