### PR TITLE
Update the sonarqube_user_token resource for the latest APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 export TF_LOG=DEBUG
 SRC=$(shell find . -name '*.go')
-SONARQUBE_IMAGE?=sonarqube:8.9.10-developer
+SONARQUBE_IMAGE?=sonarqube:9.5.0-developer
 SONARQUBE_START_SLEEP?=60
 
 .PHONY: all vet build test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 export TF_LOG=DEBUG
 SRC=$(shell find . -name '*.go')
-SONARQUBE_IMAGE?=sonarqube:9.5.0-developer
+SONARQUBE_IMAGE?=sonarqube:8.9.10-developer
 SONARQUBE_START_SLEEP?=60
 
 .PHONY: all vet build test

--- a/docs/resources/sonarqube_user_token.md
+++ b/docs/resources/sonarqube_user_token.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 - name - (Required) The name of the Token to create. Changing this forces a new resource to be created.
 - expiration_date - (Optional) The expiration date of the token being generated, in ISO 8601 format (YYYY-MM-DD). If not set, default to no expiration.
 - type - (Optional) The kind of Token to create. Changing this forces a new resource to be created. Possible values are USER_TOKEN, GLOBAL_ANALYSIS_TOKEN, or PROJECT_ANALYSIS_TOKEN. Defaults to USER_TOKEN. If set to PROJECT_ANALYSIS_TOKEN, then the project_key must also be specified.
-- project_key - (Optional) The key of the only project that can be analyzed by the PROJECT_ANALYSIS TOKEN being created.
+- project_key - (Optional) The key of the only project that can be analyzed by the PROJECT_ANALYSIS TOKEN being created. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/docs/resources/sonarqube_user_token.md
+++ b/docs/resources/sonarqube_user_token.md
@@ -21,13 +21,43 @@ output "user_token" {
 }
 ```
 
+## Example: create an expiring global analysis token and output the token value
+
+```terraform
+resource "sonarqube_user_token" "token" {
+  name = "my-token"
+  type = "GLOBAL_ANALYSIS_TOKEN"
+  expiration_date = "2099-01-01"
+}
+
+output "global_analysis_token" {
+  value = sonarqube_user_token.token.token
+}
+```
+
+## Example: create a project, project analysis token, and output the token value
+
+```terraform
+resource "sonarqube_user_token" "token" {
+  name = "my-token"
+  type = "PROJECT_ANALYSIS_TOKEN"
+  project_key = "my-project"
+}
+
+output "project_analysis_token" {
+  value = sonarqube_user_token.token.token
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-- login_name - (Required) The login name of the User for which the token should be created. Changing this forces a new resource to be created.
+- login_name - (Optional) The login name of the User for which the token should be created. If not set, the token is created for the authenticated user. Changing this forces a new resource to be created.
 - name - (Required) The name of the Token to create. Changing this forces a new resource to be created.
 - expiration_date - (Optional) The expiration date of the token being generated, in ISO 8601 format (YYYY-MM-DD). If not set, default to no expiration.
+- type - (Optional) The kind of Token to create. Changing this forces a new resource to be created. Possible values are USER_TOKEN, GLOBAL_ANALYSIS_TOKEN, or PROJECT_ANALYSIS_TOKEN. Defaults to USER_TOKEN. If set to PROJECT_ANALYSIS_TOKEN, then the project_key must also be specified.
+- project_key - (Optional) The key of the only project that can be analyzed by the PROJECT_ANALYSIS TOKEN being created.
 
 ## Attributes Reference
 

--- a/sonarqube/resource_sonarqube_user_token.go
+++ b/sonarqube/resource_sonarqube_user_token.go
@@ -101,7 +101,12 @@ func resourceSonarqubeUserTokenCreate(d *schema.ResourceData, m interface{}) err
 		"type": []string{string(tokenType)},
 	}
 
-	if tokenType == ProjectAnalysisToken {
+	if tokenType == UserToken {
+		loginName := d.Get("login_name").(string)
+		if loginName != "" {
+			rawQuery.Add("login", loginName)
+		}
+	} else if tokenType == ProjectAnalysisToken {
 		projectKey := d.Get("project_key").(string)
 		if projectKey == "" {
 			return fmt.Errorf("resourceSonarqubeUserTokenCreate: 'project_key' must be configured when the token 'type' is %s", ProjectAnalysisToken)

--- a/sonarqube/resource_sonarqube_user_token.go
+++ b/sonarqube/resource_sonarqube_user_token.go
@@ -20,26 +20,27 @@ type GetTokens struct {
 
 // Token struct
 type Token struct {
-	Login          string  `json:"login,omitempty"`
-	Name           string  `json:"name,omitempty"`
-	Token          string  `json:"token,omitempty"`
-	ExpirationDate string  `json:"expirationDate,omitempty"`
-	Type		   string  `json:"type,omitempty"`
-	CreatedAt	   string  `json:"createdAt,omitempty"`
-	IsExpired	   bool    `json:"isExpired,omitempty"`
-	Project		   Project `json:"project,omitempty"`
+	Login          string       `json:"login,omitempty"`
+	Name           string       `json:"name,omitempty"`
+	Token          string       `json:"token,omitempty"`
+	ExpirationDate string       `json:"expirationDate,omitempty"`
+	Type           string       `json:"type,omitempty"`
+	CreatedAt      string       `json:"createdAt,omitempty"`
+	IsExpired      bool         `json:"isExpired,omitempty"`
+	Project        TokenProject `json:"project,omitempty"`
 }
 
-type Project struct {
+type TokenProject struct {
 	Key  string `json:"key,omitempty"`
 	Name string `json:"name,omitempty"`
 }
 
 // Token types
 type TokenType string
+
 const (
-	UserToken TokenType = "USER_TOKEN"
-	GlobalAnalysisToken TokenType = "GLOBAL_ANALYSIS_TOKEN"
+	UserToken            TokenType = "USER_TOKEN"
+	GlobalAnalysisToken  TokenType = "GLOBAL_ANALYSIS_TOKEN"
 	ProjectAnalysisToken TokenType = "PROJECT_ANALYSIS_TOKEN"
 )
 
@@ -53,10 +54,10 @@ func resourceSonarqubeUserToken() *schema.Resource {
 		// Define the fields of this schema.
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateDiagFunc: StringLenBetween(1, 100),
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 100)),
 			},
 			"login_name": {
 				Type:     schema.TypeString,
@@ -75,14 +76,14 @@ func resourceSonarqubeUserToken() *schema.Resource {
 				Sensitive: true,
 			},
 			"type": {
-				Type:	          schema.TypeString,
+				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          UserToken,
 				ForceNew:         true,
-				ValidateDiagFunc: StringInSlice([]string{UserToken, GlobalAnalysisToken, ProjectAnalysisToken}, false),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(UserToken), string(GlobalAnalysisToken), string(ProjectAnalysisToken)}, false)),
 			},
 			"project_key": {
-				Type:	  schema.typeString,
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -94,14 +95,14 @@ func resourceSonarqubeUserTokenCreate(d *schema.ResourceData, m interface{}) err
 	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_tokens/generate"
 
-	tokenType = TokenType(d.Get("type").(string))
+	tokenType := TokenType(d.Get("type").(string))
 	rawQuery := url.Values{
-		"name":  []string{d.Get("name").(string)},
-		"type":  []string{tokenType.(string)},
+		"name": []string{d.Get("name").(string)},
+		"type": []string{string(tokenType)},
 	}
 
 	if tokenType == ProjectAnalysisToken {
-		projectKey = d.Get("project_key").(string)
+		projectKey := d.Get("project_key").(string)
 		if projectKey == "" {
 			return fmt.Errorf("resourceSonarqubeUserTokenCreate: 'project_key' must be configured when the token 'type' is %s", ProjectAnalysisToken)
 		}
@@ -205,15 +206,15 @@ func resourceSonarqubeUserTokenRead(d *schema.ResourceData, m interface{}) error
 func resourceSonarqubeUserTokenDelete(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_tokens/revoke"
-	sonarQubeURL.RawQuery = url.Values{
-		"name":  []string{d.Get("name").(string)},
+	rawQuery := url.Values{
+		"name": []string{d.Get("name").(string)},
 	}
-	login = d.Get("login_name").(string)
+	login := d.Get("login_name").(string)
 	if login != "" {
-		sonarQubeURL.RawQuery.Add("login", []string{login_name})
+		rawQuery.Add("login", login)
 	}
 
-	sonarQubeURL.RawQuery.Encode()
+	sonarQubeURL.RawQuery = rawQuery.Encode()
 
 	resp, err := httpRequestHelper(
 		m.(*ProviderConfiguration).httpClient,

--- a/sonarqube/resource_sonarqube_user_token_test.go
+++ b/sonarqube/resource_sonarqube_user_token_test.go
@@ -1,181 +1,181 @@
 package sonarqube
 
 import (
-	"fmt"
-	"testing"
-	"time"
+    "fmt"
+    "testing"
+    "time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func init() {
-	resource.AddTestSweepers("sonarqube_user_token", &resource.Sweeper{
-		Name: "sonarqube_user_token",
-		F:    testSweepSonarqubeUserTokenSweeper,
-	})
+    resource.AddTestSweepers("sonarqube_user_token", &resource.Sweeper{
+        Name: "sonarqube_user_token",
+        F:    testSweepSonarqubeUserTokenSweeper,
+    })
 }
 
 func testSweepSonarqubeUserTokenSweeper(r string) error {
-	return nil
+    return nil
 }
 
 func testAccSonarqubeUserTokenBasicConfig(rnd string, name string) string {
-	return fmt.Sprintf(`
-		resource "sonarqube_user" "%[1]s" {
-			login_name = "%[2]s"
-			name       = "%[2]s"
-			password   = "secret-sauce37!"
-		}
-		resource "sonarqube_user_token" "%[1]s" {
-			login_name = sonarqube_user.%[1]s.login_name
-			name       = "%[2]s"
-		}`, rnd, name)
+    return fmt.Sprintf(`
+        resource "sonarqube_user" "%[1]s" {
+            login_name = "%[2]s"
+            name       = "%[2]s"
+            password   = "secret-sauce37!"
+        }
+        resource "sonarqube_user_token" "%[1]s" {
+            login_name = sonarqube_user.%[1]s.login_name
+            name       = "%[2]s"
+        }`, rnd, name)
 }
 
 func TestAccSonarqubeUserTokenBasic(t *testing.T) {
-	rnd := generateRandomResourceName()
-	name := "sonarqube_user_token." + rnd
+    rnd := generateRandomResourceName()
+    name := "sonarqube_user_token." + rnd
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSonarqubeUserTokenBasicConfig(rnd, "testAccSonarqubeUserToken"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserToken"),
-				),
-			},
-		},
-	})
+    resource.Test(t, resource.TestCase{
+        PreCheck:  func() { testAccPreCheck(t) },
+        Providers: testAccProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSonarqubeUserTokenBasicConfig(rnd, "testAccSonarqubeUserToken"),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserToken"),
+                ),
+            },
+        },
+    })
 }
 
 func testAccSonarqubeUserTokenExpirationDateConfig(rnd string, name string, expiration_date string) string {
-	return fmt.Sprintf(`
-		resource "sonarqube_user" "%[1]s" {
-			login_name = "%[2]s"
-			name       = "%[2]s"
-			password   = "secret-sauce37!"
-		}
-		resource "sonarqube_user_token" "%[1]s" {
-			login_name      = sonarqube_user.%[1]s.login_name
-			name            = "%[2]s"
-			expiration_date = "%s"
-		}`, rnd, name, expiration_date)
+    return fmt.Sprintf(`
+        resource "sonarqube_user" "%[1]s" {
+            login_name = "%[2]s"
+            name       = "%[2]s"
+            password   = "secret-sauce37!"
+        }
+        resource "sonarqube_user_token" "%[1]s" {
+            login_name      = sonarqube_user.%[1]s.login_name
+            name            = "%[2]s"
+            expiration_date = "%s"
+        }`, rnd, name, expiration_date)
 }
 
 func TestAccSonarqubeUserTokenWithExpirationDate(t *testing.T) {
-	rnd := generateRandomResourceName()
-	name := "sonarqube_user_token." + rnd
-	expiration_date := time.Now().AddDate(0, 0, 5).Format("2006-01-02")
+    rnd := generateRandomResourceName()
+    name := "sonarqube_user_token." + rnd
+    expiration_date := time.Now().AddDate(0, 0, 5).Format("2006-01-02")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSonarqubeUserTokenExpirationDateConfig(rnd, "testAccSonarqubeUserTokenWithExpirationDate", expiration_date),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenWithExpirationDate"),
-					resource.TestCheckResourceAttr(name, "expiration_date", expiration_date),
-				),
-			},
-		},
-	})
+    resource.Test(t, resource.TestCase{
+        PreCheck:  func() { testAccPreCheck(t) },
+        Providers: testAccProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSonarqubeUserTokenExpirationDateConfig(rnd, "testAccSonarqubeUserTokenWithExpirationDate", expiration_date),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenWithExpirationDate"),
+                    resource.TestCheckResourceAttr(name, "expiration_date", expiration_date),
+                ),
+            },
+        },
+    })
 }
 
 func testAccSonarqubeUserTokenNoLoginConfig(rnd string, name string) string {
-	return fmt.Sprintf(`
-		resource "sonarqube_user" "%[1]s" {
-			login_name = "%[2]s"
-			name       = "%[2]s"
-			password   = "secret-sauce37!"
-		}
-		resource "sonarqube_user_token" "%[1]s" {
-			name       = "%[2]s"
-		}`, rnd, name)
+    return fmt.Sprintf(`
+        resource "sonarqube_user" "%[1]s" {
+            login_name = "%[2]s"
+            name       = "%[2]s"
+            password   = "secret-sauce37!"
+        }
+        resource "sonarqube_user_token" "%[1]s" {
+            name       = "%[2]s"
+        }`, rnd, name)
 }
 
 func testAccSonarqubeUserTokenNoLogin(t *testing.T) {
-	rnd := generateRandomResourceName()
-	name := "sonarqube_user_token." + rnd
+    rnd := generateRandomResourceName()
+    name := "sonarqube_user_token." + rnd
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSonarqubeUserTokenNoLoginConfig(rnd, "testAccSonarqubeUserTokenNoLogin"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenNoLogin"),
-					resource.TestCheckResourceAttr(name, "login", name),
-				),
-			},
-		},
-	})
+    resource.Test(t, resource.TestCase{
+        PreCheck:  func() { testAccPreCheck(t) },
+        Providers: testAccProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSonarqubeUserTokenNoLoginConfig(rnd, "testAccSonarqubeUserTokenNoLogin"),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenNoLogin"),
+                    resource.TestCheckResourceAttr(name, "login", name),
+                ),
+            },
+        },
+    })
 }
 
 func testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd string, name string) string {
-	return fmt.Sprintf(`
-		resource "sonarqube_user" "%[1]s" {
-			login_name = "%[2]s"
-			name       = "%[2]s"
-			password   = "secret-sauce37!"
-		}
-		resource "sonarqube_user_token" "%[1]s" {
-			name       = "%[2]s"
-			type       = "GLOBAL_ANALYSIS_TOKEN"
-		}`, rnd, name)
+    return fmt.Sprintf(`
+        resource "sonarqube_user" "%[1]s" {
+            login_name = "%[2]s"
+            name       = "%[2]s"
+            password   = "secret-sauce37!"
+        }
+        resource "sonarqube_user_token" "%[1]s" {
+            name       = "%[2]s"
+            type       = "GLOBAL_ANALYSIS_TOKEN"
+        }`, rnd, name)
 }
 
 func testAccSonarqubeUserTokenGlobalAnalysisToken(t *testing.T) {
-	rnd := generateRandomResourceName()
-	name := "sonarqube_user_token." + rnd
+    rnd := generateRandomResourceName()
+    name := "sonarqube_user_token." + rnd
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenGlobalAnalysisToken"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenGlobalAnalysisToken"),
-					resource.TestCheckResourceAttr(name, "type", "GLOBAL_ANALYSIS_TOKEN"),
-				),
-			},
-		},
-	})
+    resource.Test(t, resource.TestCase{
+        PreCheck:  func() { testAccPreCheck(t) },
+        Providers: testAccProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenGlobalAnalysisToken"),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenGlobalAnalysisToken"),
+                    resource.TestCheckResourceAttr(name, "type", "GLOBAL_ANALYSIS_TOKEN"),
+                ),
+            },
+        },
+    })
 }
 
 func testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd string, name string) string {
-	return fmt.Sprintf(`
-		resource "sonarqube_user" "%[1]s" {
-			login_name = "%[2]s"
-			name       = "%[2]s"
-			password   = "secret-sauce37!"
-		}
-		resource "sonarqube_user_token" "%[1]s" {
-			name        = "%[2]s"
-			type        = "PROJECT_ANALYSIS_TOKEN"
-			project_key = "my-project"
-		}`, rnd, name)
+    return fmt.Sprintf(`
+        resource "sonarqube_user" "%[1]s" {
+            login_name = "%[2]s"
+            name       = "%[2]s"
+            password   = "secret-sauce37!"
+        }
+        resource "sonarqube_user_token" "%[1]s" {
+            name        = "%[2]s"
+            type        = "PROJECT_ANALYSIS_TOKEN"
+            project_key = "my-project"
+        }`, rnd, name)
 }
 
 func testAccSonarqubeUserTokenProjectAnalysisToken(t *testing.T) {
-	rnd := generateRandomResourceName()
-	name := "sonarqube_user_token." + rnd
+    rnd := generateRandomResourceName()
+    name := "sonarqube_user_token." + rnd
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenProjectAnalysisToken"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenProjectAnalysisToken"),
-					resource.TestCheckResourceAttr(name, "type", "PROJECT_ANALYSIS_TOKEN"),
-				),
-			},
-		},
-	})
+    resource.Test(t, resource.TestCase{
+        PreCheck:  func() { testAccPreCheck(t) },
+        Providers: testAccProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenProjectAnalysisToken"),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenProjectAnalysisToken"),
+                    resource.TestCheckResourceAttr(name, "type", "PROJECT_ANALYSIS_TOKEN"),
+                ),
+            },
+        },
+    })
 }

--- a/sonarqube/resource_sonarqube_user_token_test.go
+++ b/sonarqube/resource_sonarqube_user_token_test.go
@@ -83,3 +83,98 @@ func TestAccSonarqubeUserTokenWithExpirationDate(t *testing.T) {
 		},
 	})
 }
+
+func testAccSonarqubeUserTokenNoLoginConfig(rnd string, name string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_user" "%[1]s" {
+			login_name = "%[2]s"
+			name       = "%[2]s"
+			password   = "secret-sauce37!"
+		}
+		resource "sonarqube_user_token" "%[1]s" {
+			name       = "%[2]s"
+		}`, rnd, name)
+}
+
+func testAccSonarqubeUserTokenNoLogin(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenNoLoginConfig(rnd, "testAccSonarqubeUserTokenNoLogin"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenNoLogin"),
+					resource.TestCheckResourceAttr(name, "login", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd string, name string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_user" "%[1]s" {
+			login_name = "%[2]s"
+			name       = "%[2]s"
+			password   = "secret-sauce37!"
+		}
+		resource "sonarqube_user_token" "%[1]s" {
+			name       = "%[2]s"
+			type       = "GLOBAL_ANALYSIS_TOKEN"
+		}`, rnd, name)
+}
+
+func testAccSonarqubeUserTokenGlobalAnalysisToken(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenGlobalAnalysisToken"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenGlobalAnalysisToken"),
+					resource.TestCheckResourceAttr(name, "type", "GLOBAL_ANALYSIS_TOKEN"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd string, name string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_user" "%[1]s" {
+			login_name = "%[2]s"
+			name       = "%[2]s"
+			password   = "secret-sauce37!"
+		}
+		resource "sonarqube_user_token" "%[1]s" {
+			name       = "%[2]s"
+			type       = "PROJECT_ANALYSIS_TOKEN"
+		}`, rnd, name)
+}
+
+func testAccSonarqubeUserTokenProjectAnalysisToken(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenProjectAnalysisToken"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenProjectAnalysisToken"),
+					resource.TestCheckResourceAttr(name, "type", "PROJECT_ANALYSIS_TOKEN"),
+				),
+			},
+		},
+	})
+}

--- a/sonarqube/resource_sonarqube_user_token_test.go
+++ b/sonarqube/resource_sonarqube_user_token_test.go
@@ -155,8 +155,9 @@ func testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd string, name string
 			password   = "secret-sauce37!"
 		}
 		resource "sonarqube_user_token" "%[1]s" {
-			name       = "%[2]s"
-			type       = "PROJECT_ANALYSIS_TOKEN"
+			name        = "%[2]s"
+			type        = "PROJECT_ANALYSIS_TOKEN"
+			project_key = "my-project"
 		}`, rnd, name)
 }
 

--- a/sonarqube/resource_sonarqube_user_token_test.go
+++ b/sonarqube/resource_sonarqube_user_token_test.go
@@ -1,26 +1,26 @@
 package sonarqube
 
 import (
-    "fmt"
-    "testing"
-    "time"
+	"fmt"
+	"testing"
+	"time"
 
-    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func init() {
-    resource.AddTestSweepers("sonarqube_user_token", &resource.Sweeper{
-        Name: "sonarqube_user_token",
-        F:    testSweepSonarqubeUserTokenSweeper,
-    })
+	resource.AddTestSweepers("sonarqube_user_token", &resource.Sweeper{
+		Name: "sonarqube_user_token",
+		F:    testSweepSonarqubeUserTokenSweeper,
+	})
 }
 
 func testSweepSonarqubeUserTokenSweeper(r string) error {
-    return nil
+	return nil
 }
 
 func testAccSonarqubeUserTokenBasicConfig(rnd string, name string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
         resource "sonarqube_user" "%[1]s" {
             login_name = "%[2]s"
             name       = "%[2]s"
@@ -33,25 +33,25 @@ func testAccSonarqubeUserTokenBasicConfig(rnd string, name string) string {
 }
 
 func TestAccSonarqubeUserTokenBasic(t *testing.T) {
-    rnd := generateRandomResourceName()
-    name := "sonarqube_user_token." + rnd
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
 
-    resource.Test(t, resource.TestCase{
-        PreCheck:  func() { testAccPreCheck(t) },
-        Providers: testAccProviders,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccSonarqubeUserTokenBasicConfig(rnd, "testAccSonarqubeUserToken"),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserToken"),
-                ),
-            },
-        },
-    })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenBasicConfig(rnd, "testAccSonarqubeUserToken"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserToken"),
+				),
+			},
+		},
+	})
 }
 
 func testAccSonarqubeUserTokenExpirationDateConfig(rnd string, name string, expiration_date string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
         resource "sonarqube_user" "%[1]s" {
             login_name = "%[2]s"
             name       = "%[2]s"
@@ -65,27 +65,27 @@ func testAccSonarqubeUserTokenExpirationDateConfig(rnd string, name string, expi
 }
 
 func TestAccSonarqubeUserTokenWithExpirationDate(t *testing.T) {
-    rnd := generateRandomResourceName()
-    name := "sonarqube_user_token." + rnd
-    expiration_date := time.Now().AddDate(0, 0, 5).Format("2006-01-02")
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
+	expiration_date := time.Now().AddDate(0, 0, 5).Format("2006-01-02")
 
-    resource.Test(t, resource.TestCase{
-        PreCheck:  func() { testAccPreCheck(t) },
-        Providers: testAccProviders,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccSonarqubeUserTokenExpirationDateConfig(rnd, "testAccSonarqubeUserTokenWithExpirationDate", expiration_date),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenWithExpirationDate"),
-                    resource.TestCheckResourceAttr(name, "expiration_date", expiration_date),
-                ),
-            },
-        },
-    })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenExpirationDateConfig(rnd, "testAccSonarqubeUserTokenWithExpirationDate", expiration_date),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenWithExpirationDate"),
+					resource.TestCheckResourceAttr(name, "expiration_date", expiration_date),
+				),
+			},
+		},
+	})
 }
 
 func testAccSonarqubeUserTokenNoLoginConfig(rnd string, name string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
         resource "sonarqube_user" "%[1]s" {
             login_name = "%[2]s"
             name       = "%[2]s"
@@ -97,26 +97,26 @@ func testAccSonarqubeUserTokenNoLoginConfig(rnd string, name string) string {
 }
 
 func testAccSonarqubeUserTokenNoLogin(t *testing.T) {
-    rnd := generateRandomResourceName()
-    name := "sonarqube_user_token." + rnd
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
 
-    resource.Test(t, resource.TestCase{
-        PreCheck:  func() { testAccPreCheck(t) },
-        Providers: testAccProviders,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccSonarqubeUserTokenNoLoginConfig(rnd, "testAccSonarqubeUserTokenNoLogin"),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenNoLogin"),
-                    resource.TestCheckResourceAttr(name, "login", name),
-                ),
-            },
-        },
-    })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenNoLoginConfig(rnd, "testAccSonarqubeUserTokenNoLogin"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenNoLogin"),
+					resource.TestCheckResourceAttr(name, "login", name),
+				),
+			},
+		},
+	})
 }
 
 func testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd string, name string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
         resource "sonarqube_user" "%[1]s" {
             login_name = "%[2]s"
             name       = "%[2]s"
@@ -129,26 +129,26 @@ func testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd string, name string)
 }
 
 func testAccSonarqubeUserTokenGlobalAnalysisToken(t *testing.T) {
-    rnd := generateRandomResourceName()
-    name := "sonarqube_user_token." + rnd
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
 
-    resource.Test(t, resource.TestCase{
-        PreCheck:  func() { testAccPreCheck(t) },
-        Providers: testAccProviders,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenGlobalAnalysisToken"),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenGlobalAnalysisToken"),
-                    resource.TestCheckResourceAttr(name, "type", "GLOBAL_ANALYSIS_TOKEN"),
-                ),
-            },
-        },
-    })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenGlobalAnalysisToken"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenGlobalAnalysisToken"),
+					resource.TestCheckResourceAttr(name, "type", "GLOBAL_ANALYSIS_TOKEN"),
+				),
+			},
+		},
+	})
 }
 
 func testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd string, name string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
         resource "sonarqube_user" "%[1]s" {
             login_name = "%[2]s"
             name       = "%[2]s"
@@ -162,20 +162,20 @@ func testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd string, name string
 }
 
 func testAccSonarqubeUserTokenProjectAnalysisToken(t *testing.T) {
-    rnd := generateRandomResourceName()
-    name := "sonarqube_user_token." + rnd
+	rnd := generateRandomResourceName()
+	name := "sonarqube_user_token." + rnd
 
-    resource.Test(t, resource.TestCase{
-        PreCheck:  func() { testAccPreCheck(t) },
-        Providers: testAccProviders,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenProjectAnalysisToken"),
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenProjectAnalysisToken"),
-                    resource.TestCheckResourceAttr(name, "type", "PROJECT_ANALYSIS_TOKEN"),
-                ),
-            },
-        },
-    })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenProjectAnalysisToken"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenProjectAnalysisToken"),
+					resource.TestCheckResourceAttr(name, "type", "PROJECT_ANALYSIS_TOKEN"),
+				),
+			},
+		},
+	})
 }


### PR DESCRIPTION
This is an update to the sonarqube_user_token resource, specifically to support #89, but this also matches the latest version of the API (e.g.: login_name is now optional, etc).

This is my first time writing any Go code, so feel free to be as nit-picky as you wish. I did write tests, but was unable to get the `make -i testacc` command to work locally. `make` does build just fine though.