### PR TITLE
Resource to manage quality gate permissions

### DIFF
--- a/docs/resources/sonarqube_qualitygate_permission.md
+++ b/docs/resources/sonarqube_qualitygate_permission.md
@@ -1,0 +1,47 @@
+# sonarqube_qualitygate_permission
+
+Provides a Sonarqube Quality Gate Permission resource. This can be used to assign `edit` permissions on a quality gate to users or groups.
+This feature is available on SonarQube `9.2` or newer.
+
+## Example: grant permission to a user
+
+```terraform
+resource "sonarqube_qualitygate" "main" {
+    name = "my_qualitygate"
+}
+
+resource "sonarqube_user" "user" {
+	login_name = "testuser"
+	name       = "Test User"
+	email      = "terraform-test@sonarqube.com"
+	password   = "secret-sauce!"
+}
+
+resource "sonarqube_qualitygate_permission" "permission" {
+	gatename = sonarqube_qualitygate.main.name
+	type      = "user"
+	subject   = sonarqube_user.user.login_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `gatename` - (Required) The name of the Quality Gate. Changing this forces a new resource to be created.
+- `type` - (Required) The type of the subject to give permission. Only `user` and `group` are valid values. Changing this forces a new resource to be created.
+- `subject` - (Required) A user's `login_name` or a group's `name` depending on the *type*. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - The ID of the permission assignment.
+
+## Import
+
+Assignments can be imported using their ID (`<gatename>[<type>/<subject>]`):
+
+```terraform
+terraform import sonarqube_qualitygate_permission.permission my-qualitygate[user/my-user]
+```

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -78,6 +78,7 @@ func Provider() *schema.Provider {
 			"sonarqube_qualitygate":                        resourceSonarqubeQualityGate(),
 			"sonarqube_qualitygate_condition":              resourceSonarqubeQualityGateCondition(),
 			"sonarqube_qualitygate_project_association":    resourceSonarqubeQualityGateProjectAssociation(),
+			"sonarqube_qualitygate_permission":             resourceSonarqubeQualityGatePermission(),
 			"sonarqube_user":                               resourceSonarqubeUser(),
 			"sonarqube_user_external_identity":             resourceSonarqubeUserExternalIdentity(),
 			"sonarqube_user_token":                         resourceSonarqubeUserToken(),

--- a/sonarqube/resource_sonarqube_qualitygate_permission.go
+++ b/sonarqube/resource_sonarqube_qualitygate_permission.go
@@ -1,0 +1,265 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type GatePermissionUser struct {
+	LoginName string `json:"login,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+type GetGatePermissionUsersResponse struct {
+	Paging Paging               `json:"paging"`
+	Users  []GatePermissionUser `json:"users"`
+}
+
+type GatePermissionGroup struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type GetGatePermissionGroupResponse struct {
+	Paging Paging                `json:"paging"`
+	Groups []GatePermissionGroup `json:"groups"`
+}
+
+// Returns the resource represented by this file.
+func resourceSonarqubeQualityGatePermission() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeQualityGatePermissionCreate,
+		Read:   resourceSonarqubeQualityGatePermissionRead,
+		Delete: resourceSonarqubeQualityGatePermissionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubeQualityGatePermissionImport,
+		},
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"gatename": {
+				Type:        schema.TypeString,
+				Description: "Name of the quality gate",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "Type of permission (user or group)",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"subject": {
+				Type:        schema.TypeString,
+				Description: "Login name or group name",
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceSonarqubeQualityGatePermissionCreate(d *schema.ResourceData, m interface{}) error {
+	if err := checkGatePermissionFeatureSupport(m.(*ProviderConfiguration)); err != nil {
+		return err
+	}
+
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+
+	switch t := d.Get("type").(string); t {
+	case "user":
+		sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualitygates/add_user"
+		sonarQubeURL.RawQuery = url.Values{
+			"gateName": []string{d.Get("gatename").(string)},
+			"login":    []string{d.Get("subject").(string)},
+		}.Encode()
+	case "group":
+		sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualitygates/add_group"
+		sonarQubeURL.RawQuery = url.Values{
+			"gateName":  []string{d.Get("gatename").(string)},
+			"groupName": []string{d.Get("subject").(string)},
+		}.Encode()
+	default:
+		return fmt.Errorf("Invalid value for 'type' parameter: '%s'", d.Get("type").(string))
+	}
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceQualityGatePermissionCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceQualityGatePermissionCreate: error creating Sonarqube %s '%s' permission on quality gate '%s': %w",
+			d.Get("type").(string), d.Get("subject").(string), d.Get("gatename").(string), err)
+	}
+	defer resp.Body.Close()
+
+	d.SetId(createGatePermissionId(d.Get("gatename").(string), d.Get("type").(string), d.Get("subject").(string)))
+
+	return resourceSonarqubeQualityGatePermissionRead(d, m)
+}
+
+func resourceSonarqubeQualityGatePermissionRead(d *schema.ResourceData, m interface{}) error {
+	if err := checkGatePermissionFeatureSupport(m.(*ProviderConfiguration)); err != nil {
+		return err
+	}
+
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+
+	switch t := d.Get("type").(string); t {
+	case "user":
+		sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualitygates/search_users"
+	case "group":
+		sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualitygates/search_groups"
+	default:
+		return fmt.Errorf("Invalid value for 'type' parameter: '%s'", d.Get("type").(string))
+	}
+	sonarQubeURL.RawQuery = url.Values{
+		"gateName": []string{d.Get("gatename").(string)},
+		"q":        []string{d.Get("subject").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeQualityGatePermissionRead",
+	)
+	if err != nil {
+		return fmt.Errorf("error reading Sonarqube permissions on quality gate '%s': %w", d.Get("gatename").(string), err)
+	}
+	defer resp.Body.Close()
+
+	readSuccess := false
+
+	switch t := d.Get("type").(string); t {
+	case "user":
+		// Decode response into struct
+		readResponse := GetGatePermissionUsersResponse{}
+		err = json.NewDecoder(resp.Body).Decode(&readResponse)
+		if err != nil {
+			return fmt.Errorf("resourceQualityGatePermissionCreate: Failed to read user '%s' permission on quality gate '%s': %+v",
+				d.Get("subject").(string), d.Get("gatename").(string), err)
+		}
+		// Loop over all returned members to see if the member we need exists.
+		for _, value := range readResponse.Users {
+			if d.Get("subject").(string) == value.LoginName {
+				// If it does, set the values of that group membership
+				d.SetId(createGatePermissionId(d.Get("gatename").(string), d.Get("type").(string), d.Get("subject").(string)))
+				d.Set("subject", value.LoginName)
+				readSuccess = true
+				break
+			}
+		}
+	case "group":
+		// Decode response into struct
+		readResponse := GetGatePermissionGroupResponse{}
+		err = json.NewDecoder(resp.Body).Decode(&readResponse)
+		if err != nil {
+			return fmt.Errorf("resourceSonarqubeQualityGatePermissionRead: Failed to read group '%s' permission on quality gate '%s': %+v",
+				d.Get("subject").(string), d.Get("gatename").(string), err)
+		}
+		// Loop over all returned members to see if the member we need exists.
+		for _, value := range readResponse.Groups {
+			if d.Get("subject").(string) == value.Name {
+				// If it does, set the values of that group membership
+				d.SetId(createGatePermissionId(d.Get("gatename").(string), d.Get("type").(string), d.Get("subject").(string)))
+				d.Set("subject", value.Name)
+				readSuccess = true
+				break
+			}
+		}
+	default:
+		return fmt.Errorf("Invalid value for 'type' parameter: '%s'", d.Get("type").(string))
+	}
+
+	if !readSuccess {
+		return fmt.Errorf("resourceSonarqubeQualityGatePermissionRead: Failed to read %s '%s' permission on quality gate '%s': not found",
+			d.Get("type").(string), d.Get("subject").(string), d.Get("gatename").(string))
+	}
+
+	return nil
+}
+
+func resourceSonarqubeQualityGatePermissionDelete(d *schema.ResourceData, m interface{}) error {
+	if err := checkGatePermissionFeatureSupport(m.(*ProviderConfiguration)); err != nil {
+		return err
+	}
+
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+
+	switch t := d.Get("type").(string); t {
+	case "user":
+		sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualitygates/remove_user"
+		sonarQubeURL.RawQuery = url.Values{
+			"gateName": []string{d.Get("gatename").(string)},
+			"login":    []string{d.Get("subject").(string)},
+		}.Encode()
+	case "group":
+		sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualitygates/remove_group"
+		sonarQubeURL.RawQuery = url.Values{
+			"gateName":  []string{d.Get("gatename").(string)},
+			"groupName": []string{d.Get("subject").(string)},
+		}.Encode()
+	default:
+		return fmt.Errorf("Invalid value for 'type' parameter: '%s'", d.Get("type").(string))
+	}
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceQualityGatePermissionDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceQualityGatePermissionDelete: error removing Sonarqube %s '%s' permission on quality gate '%s': %w",
+			d.Get("type").(string), d.Get("subject").(string), d.Get("gatename").(string), err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeQualityGatePermissionImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if err := checkGatePermissionFeatureSupport(m.(*ProviderConfiguration)); err != nil {
+		return nil, err
+	}
+
+	rgx := regexp.MustCompile(`(.*?)\[(.*?)/(.*?)\]`)
+	rs := rgx.FindStringSubmatch(d.Id())
+	gateName := rs[1]
+	subjectType := rs[2]
+	subject := rs[3]
+
+	d.Set("gatename", gateName)
+	d.Set("type", subjectType)
+	d.Set("subject", subject)
+
+	if err := resourceSonarqubeQualityGatePermissionRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}
+
+func createGatePermissionId(gateName string, subjectType string, subject string) string {
+	return gateName + "[" + subjectType + "/" + subject + "]"
+}
+
+func checkGatePermissionFeatureSupport(conf *ProviderConfiguration) error {
+	minimumVersion, _ := version.NewVersion("9.2")
+	if conf.sonarQubeVersion.LessThan(minimumVersion) {
+		return fmt.Errorf("Minimum required SonarQube version for quality gate permissions is %s", minimumVersion)
+	}
+	return nil
+}

--- a/sonarqube/resource_sonarqube_qualitygate_permission_test.go
+++ b/sonarqube/resource_sonarqube_qualitygate_permission_test.go
@@ -1,0 +1,96 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("sonarqube_group_qualitygate_permission", &resource.Sweeper{
+		Name: "sonarqube_group_qualitygate_permission",
+		F:    testSweepSonarqubeQualitygatePermissionSweeper,
+	})
+}
+
+func testSweepSonarqubeQualitygatePermissionSweeper(r string) error {
+	return nil
+}
+
+func testAccPreCheckQualityGatePermissionFeature(t *testing.T) {
+	sonarQubeVersion := testAccProvider.Meta().(*ProviderConfiguration).sonarQubeVersion
+
+	minimumVersion, _ := version.NewVersion("9.2")
+	if sonarQubeVersion.LessThan(minimumVersion) {
+		t.Skipf("Skipping test of unsupported feature")
+	}
+}
+
+func testAccSonarqubeQualitygatePermissionUserConfig(rnd string, gateName string, loginName string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_user" "%[1]s_user" {
+			login_name = "%[3]s"
+			name       = "Test User"
+			email      = "terraform-test@sonarqube.com"
+			password   = "secret-sauce!"
+		}
+
+		resource "sonarqube_qualitygate" "%[1]s_gate" {
+			name = "%[2]s"
+		}
+
+		resource "sonarqube_qualitygate_permission" "%[1]s" {
+			gatename = sonarqube_qualitygate.%[1]s_gate.name
+			type     = "user"
+			subject  = sonarqube_user.%[1]s_user.login_name
+		}
+		`, rnd, gateName, loginName)
+}
+
+func testAccSonarqubeQualitygatePermissionGroupConfig(rnd string, gateName string, groupName string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_group" "%[1]s_group" {
+			name = "%[3]s"
+		}
+
+		resource "sonarqube_qualitygate" "%[1]s_gate" {
+			name = "%[2]s"
+		}
+
+		resource "sonarqube_qualitygate_permission" "%[1]s" {
+			gatename = sonarqube_qualitygate.%[1]s_gate.name
+			type     = "group"
+			subject  = sonarqube_group.%[1]s_group.name
+		}
+		`, rnd, gateName, groupName)
+}
+
+func TestAccSonarqubeQualitygatePermissionBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_qualitygate_permission." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckQualityGatePermissionFeature(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeQualitygatePermissionUserConfig(rnd, "testAccSonarqubeQualtiyGate", "testAccSonarqubeUser"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "gatename", "testAccSonarqubeQualtiyGate"),
+					resource.TestCheckResourceAttr(name, "type", "user"),
+					resource.TestCheckResourceAttr(name, "subject", "testAccSonarqubeUser"),
+				),
+			},
+			{
+				Config: testAccSonarqubeQualitygatePermissionGroupConfig(rnd, "testAccSonarqubeQualtiyGate", "testAccSonarqubeGroup"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "gatename", "testAccSonarqubeQualtiyGate"),
+					resource.TestCheckResourceAttr(name, "type", "group"),
+					resource.TestCheckResourceAttr(name, "subject", "testAccSonarqubeGroup"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
This adds a sonarqube_qualitygate_permission` resource to manage edit permissions on quality gates. This is available since SonarQube 9.2 and I've added a check that the target instance is supported. I can contribute the same for quality profiles if this gets accepted.