### PR TITLE
Support the new_code_periods APIs

### DIFF
--- a/docs/resources/sonarqube_new_code_periods.md
+++ b/docs/resources/sonarqube_new_code_periods.md
@@ -1,0 +1,44 @@
+# sonarqube_new_code_periods
+
+Provides a Sonarqube New Code Periods resource. This can be used to manage Sonarqube New Code Periods.
+
+## Example: Set the global new code period to a number of days
+
+```terraform
+resource "sonarqube_new_code_periods" "code_period" {
+  type = "NUMBER_OF_DAYS"
+  value = "7"
+}
+```
+
+## Example: create a project and set its new code period to a reference branch
+
+```terraform
+resource "sonarqube_project" "reference" {
+  name = "my-project"
+}
+
+resource "sonarqube_new_code_period" "reference" {
+  project = sonarqube_project.reference.project
+  type = "REFERENCE_BRANCH"
+  value = "main"
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- type - (Required) The kind of new code period to use. Supported values are SPECIFIC_ANALYSIS, PREVIOUS_VERSION, NUMBER_OF_DAYS, or REFERENCE_BRANCH.
+- project - (Optional) The key of a project for which the new code period will be configured. Changing this will force a new resource to be created.
+- branch - (Optional) The name of a branch of a project for which the new code period will be configured. Changing this will force a new resource to be created. Setting this also requires setting the 'project' argument.
+- value - (Optional) The desired value of the new code period. Varies based on the 'type'. For SPECIFIC_ANALYIS, the value must be the UUID of a previous analysis. For NUMBER_OF_DAYS it must be a numeric string. For REFERENCE_BRANCH it should be the name of branch on the project. For PREVIOUS_VERSION it must **not** be set.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- id - The ID of the Token.
+
+## Import
+
+Import is not supported for this resource.

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -90,6 +90,7 @@ func Provider() *schema.Provider {
 			"sonarqube_github_binding":                     resourceSonarqubeGithubBinding(),
 			"sonarqube_alm_gitlab":                         resourceSonarqubeAlmGitlab(),
 			"sonarqube_gitlab_binding":                     resourceSonarqubeGitlabBinding(),
+			"sonarqube_new_code_periods":                   resourceSonarqubeNewCodePeriodsBinding(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sonarqube_user":           dataSourceSonarqubeUser(),

--- a/sonarqube/resource_sonarqube_new_code_periods.go
+++ b/sonarqube/resource_sonarqube_new_code_periods.go
@@ -76,7 +76,7 @@ func resourceSonarqubeNewCodePeriodsCreate(d *schema.ResourceData, m interface{}
 		"type": []string{string(periodType)},
 	}
 
-	id := string(periodType)
+	id := "newCodePeriod"
 
 	branch := d.Get("branch").(string)
 	project := d.Get("project").(string)
@@ -171,7 +171,7 @@ func resourceSonarqubeNewCodePeriodsRead(d *schema.ResourceData, m interface{}) 
 	}
 	// Check that the project and branch match
 	if branch == NewCodePeriodsReadResponse.Branch && project == NewCodePeriodsReadResponse.Project {
-		id := NewCodePeriodsReadResponse.Type
+		id := "newCodePeriod"
 		if NewCodePeriodsReadResponse.Branch != "" {
 			id += "/" + NewCodePeriodsReadResponse.Branch
 		}

--- a/sonarqube/resource_sonarqube_new_code_periods.go
+++ b/sonarqube/resource_sonarqube_new_code_periods.go
@@ -101,12 +101,18 @@ func resourceSonarqubeNewCodePeriodsCreate(d *schema.ResourceData, m interface{}
 		rawQuery.Add("value", value)
 	}
 
-	if periodType == PreviousVersion && value != "" {
-		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'value' must be unset when the 'type' is %s", periodType)
-	} else if periodType == SpecificAnalysis && branch == "" {
+	if periodType == PreviousVersion {
+		if value != "" {
+			return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'value' must be unset when the 'type' is %s", periodType)
+		}
+	} else if value == "" {
+		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'value' must be configured when the 'type' is %s", periodType)
+	}
+
+	if periodType == SpecificAnalysis && branch == "" {
 		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'branch' must be configured when the 'type' is %s", periodType)
-	} else if periodType == ReferenceBranch && (branch == "" && project == "") {
-		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: both of 'branch' and 'project' must be configured when the 'type' is %s", periodType)
+	} else if periodType == ReferenceBranch && branch == "" && project == "" {
+		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: both 'branch' and 'project' must be configured when the 'type' is %s", periodType)
 	} else if periodType == NumberOfDays && !regexp.MustCompile(`^\d+$`).MatchString(value) {
 		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'value' must be a numeric string when the 'type' is %s", periodType)
 	}
@@ -117,7 +123,7 @@ func resourceSonarqubeNewCodePeriodsCreate(d *schema.ResourceData, m interface{}
 		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
-		http.StatusNoContent,
+		http.StatusOK,
 		"resourceSonarqubeNewCodePeriodsCreate",
 	)
 	if err != nil {
@@ -198,7 +204,7 @@ func resourceSonarqubeNewCodePeriodsDelete(d *schema.ResourceData, m interface{}
 		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
-		http.StatusNoContent,
+		http.StatusOK,
 		"resourceSonarqubeNewCodePeriodsDelete",
 	)
 	if err != nil {

--- a/sonarqube/resource_sonarqube_new_code_periods.go
+++ b/sonarqube/resource_sonarqube_new_code_periods.go
@@ -1,0 +1,210 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// NewCodePeriods for unmarshalling response body from new_code_periods list definitions.
+type NewCodePeriod struct {
+	Project        string `json:"projectKey"`
+	Branch         string `json:"branchKey"`
+	Type           string `json:"type"`
+	Value          string `json:"value,omitempty"`
+	EffectiveValue string `json:"effectiveValue"`
+	Inherited      bool   `json:"inherited"`
+}
+
+// New Code Period types
+type NewCodePeriodType string
+
+const (
+	SpecificAnalysis NewCodePeriodType = "SPECIFIC_ANALYSIS"
+	PreviousVersion  NewCodePeriodType = "PREVIOUS_VERSION"
+	NumberOfDays     NewCodePeriodType = "NUMBER_OF_DAYS"
+	ReferenceBranch  NewCodePeriodType = "REFERENCE_BRANCH"
+)
+
+// Returns the resource represented by this file.
+func resourceSonarqubeNewCodePeriodsBinding() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeNewCodePeriodsCreate,
+		Read:   resourceSonarqubeNewCodePeriodsRead,
+		Update: resourceSonarqubeNewCodePeriodsCreate,
+		Delete: resourceSonarqubeNewCodePeriodsDelete,
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"branch": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         false,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(SpecificAnalysis), string(PreviousVersion), string(NumberOfDays), string(ReferenceBranch)}, false)),
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+		},
+	}
+}
+
+func resourceSonarqubeNewCodePeriodsCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/new_code_periods/set"
+
+	periodType := NewCodePeriodType(d.Get("type").(string))
+	rawQuery := url.Values{
+		"type": []string{string(periodType)},
+	}
+
+	id := string(periodType)
+
+	branch := d.Get("branch").(string)
+	project := d.Get("project").(string)
+	value := d.Get("value").(string)
+
+	// If branch is set, project must also be set
+	if branch != "" {
+		if project == "" {
+			return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'project' must be configured when 'branch' is set")
+		}
+
+		rawQuery.Add("branch", branch)
+		id += "/" + branch
+
+		rawQuery.Add("project", project)
+		id += "/" + project
+	} else if project != "" {
+		rawQuery.Add("project", project)
+		id += "/" + project
+	}
+	if value != "" {
+		rawQuery.Add("value", value)
+	}
+
+	if periodType == PreviousVersion && value != "" {
+		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'value' must be unset when the 'type' is %s", periodType)
+	} else if periodType == SpecificAnalysis && branch == "" {
+		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'branch' must be configured when the 'type' is %s", periodType)
+	} else if periodType == ReferenceBranch && (branch == "" && project == "") {
+		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: both of 'branch' and 'project' must be configured when the 'type' is %s", periodType)
+	} else if periodType == NumberOfDays && !regexp.MustCompile(`^\d+$`).MatchString(value) {
+		return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'value' must be a numeric string when the 'type' is %s", periodType)
+	}
+
+	sonarQubeURL.RawQuery = rawQuery.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeNewCodePeriodsCreate",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	d.SetId(id)
+
+	return resourceSonarqubeNewCodePeriodsRead(d, m)
+}
+
+func resourceSonarqubeNewCodePeriodsRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/new_code_periods/show"
+
+	rawQuery := url.Values{}
+	branch := d.Get("branch").(string)
+	if branch != "" {
+		rawQuery.Add("branch", branch)
+	}
+	project := d.Get("project").(string)
+	if project != "" {
+		rawQuery.Add("project", project)
+	}
+	sonarQubeURL.RawQuery = rawQuery.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeNewCodePeriodsRead",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	NewCodePeriodsReadResponse := NewCodePeriod{}
+	err = json.NewDecoder(resp.Body).Decode(&NewCodePeriodsReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeNewCodePeriodsRead: Failed to decode json into struct: %+v", err)
+	}
+	// Check that the project and branch match
+	if branch == NewCodePeriodsReadResponse.Branch && project == NewCodePeriodsReadResponse.Project {
+		id := NewCodePeriodsReadResponse.Type
+		if NewCodePeriodsReadResponse.Branch != "" {
+			id += "/" + NewCodePeriodsReadResponse.Branch
+		}
+		if NewCodePeriodsReadResponse.Project != "" {
+			id += "/" + NewCodePeriodsReadResponse.Project
+		}
+		d.SetId(id)
+		return nil
+	}
+
+	return fmt.Errorf("resourceSonarqubeNewCodePeriodsRead: Failed to find new code period: %+v", d.Id())
+}
+
+func resourceSonarqubeNewCodePeriodsDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/new_code_periods/unset"
+
+	rawQuery := url.Values{}
+	branch := d.Get("branch").(string)
+	if branch != "" {
+		rawQuery.Add("branch", branch)
+	}
+	project := d.Get("project").(string)
+	if project != "" {
+		rawQuery.Add("project", project)
+	}
+	sonarQubeURL.RawQuery = rawQuery.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeNewCodePeriodsDelete",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/sonarqube/resource_sonarqube_new_code_periods.go
+++ b/sonarqube/resource_sonarqube_new_code_periods.go
@@ -55,13 +55,11 @@ func resourceSonarqubeNewCodePeriodsBinding() *schema.Resource {
 			"type": {
 				Type:             schema.TypeString,
 				Required:         true,
-				ForceNew:         false,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(SpecificAnalysis), string(PreviousVersion), string(NumberOfDays), string(ReferenceBranch)}, false)),
 			},
 			"value": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: false,
 			},
 		},
 	}

--- a/sonarqube/resource_sonarqube_new_code_periods.go
+++ b/sonarqube/resource_sonarqube_new_code_periods.go
@@ -43,9 +43,10 @@ func resourceSonarqubeNewCodePeriodsBinding() *schema.Resource {
 		// Define the fields of this schema.
 		Schema: map[string]*schema.Schema{
 			"branch": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"project"},
 			},
 			"project": {
 				Type:     schema.TypeString,
@@ -80,12 +81,7 @@ func resourceSonarqubeNewCodePeriodsCreate(d *schema.ResourceData, m interface{}
 	project := d.Get("project").(string)
 	value := d.Get("value").(string)
 
-	// If branch is set, project must also be set
 	if branch != "" {
-		if project == "" {
-			return fmt.Errorf("resourceSonarqubeNewCodePeriodsCreate: 'project' must be configured when 'branch' is set")
-		}
-
 		rawQuery.Add("branch", branch)
 		id += "/" + branch
 

--- a/sonarqube/resource_sonarqube_new_code_periods_test.go
+++ b/sonarqube/resource_sonarqube_new_code_periods_test.go
@@ -1,0 +1,321 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("sonarqube_new_code_periods", &resource.Sweeper{
+		Name: "sonarqube_new_code_periods",
+		F:    testSweepSonarqubeNewCodePeriods,
+	})
+}
+
+// TODO: implement sweeper to clean up projects: https://www.terraform.io/docs/extend/testing/acceptance-tests/sweepers.html
+func testSweepSonarqubeNewCodePeriods(r string) error {
+	return nil
+}
+
+func testAccSonarqubeNewCodePeriodsGlobalPreviousVersion(rnd string) string {
+	return fmt.Sprintf(`
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			type = "PREVIOUS_VERSION"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsGlobalPreviousVersion(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsGlobalPreviousVersion(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "PREVIOUS_VERSION"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeNewCodePeriodsGlobalNumberOfDays(rnd string) string {
+	return fmt.Sprintf(`
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			type = "NUMBER_OF_DAYS"
+			value = "5"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsGlobalNumberOfDays(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsGlobalNumberOfDays(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "NUMBER_OF_DAYS"),
+					resource.TestCheckResourceAttr(name, "value", "5"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeNewCodePeriodsBranchPreviousVersion(rnd string) string {
+	return fmt.Sprintf(`
+	    resource "sonarqube_project" "%[1]s" {
+			name = "%[1]s"
+			project = "%[1]s"
+			visibility = "public"
+		}
+
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			branch = "main"
+			project = sonarqube_project.%[1]s.project
+			type = "PREVIOUS_VERSION"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsBranchPreviousVersion(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsBranchPreviousVersion(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "PREVIOUS_VERSION"),
+					resource.TestCheckResourceAttr(name, "branch", "main"),
+					resource.TestCheckResourceAttr(name, "project", rnd),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeNewCodePeriodsBranchNumberOfDays(rnd string) string {
+	return fmt.Sprintf(`
+	    resource "sonarqube_project" "%[1]s" {
+			name = "%[1]s"
+			project = "%[1]s"
+			visibility = "public"
+		}
+
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			branch = "main"
+			project = sonarqube_project.%[1]s.project
+			type = "NUMBER_OF_DAYS"
+			value = "5"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsBranchNumberOfDays(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsBranchNumberOfDays(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "NUMBER_OF_DAYS"),
+					resource.TestCheckResourceAttr(name, "branch", "main"),
+					resource.TestCheckResourceAttr(name, "project", rnd),
+					resource.TestCheckResourceAttr(name, "value", "5"),
+				),
+			},
+		},
+	})
+}
+
+// Note sure how to get a specific analysis UUID on the fly in a test environment
+//
+// func testAccSonarqubeNewCodePeriodsBranchSpecificAnalysis(rnd string) string {
+// 	return fmt.Sprintf(`
+// 	    resource "sonarqube_project" "%[1]s" {
+// 			name = "%[1]s"
+// 			project = "%[1]s"
+// 			visibility = "public"
+// 		}
+// 
+//         resource "sonarqube_new_code_periods" "%[1]s" {
+// 			branch = "main"
+// 			project = sonarqube_project.%[1]s.project
+// 			type = "SPECIFIC_ANALYSIS"
+//         }`, rnd)
+// }
+// 
+// func TestAccSonarqubeNewCodePeriodsBranchSpecificAnalysis(t *testing.T) {
+// 	rnd := generateRandomResourceName()
+// 	name := "sonarqube_new_code_periods." + rnd
+// 
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:  func() { testAccPreCheck(t) },
+// 		Providers: testAccProviders,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccSonarqubeNewCodePeriodsBranchSpecificAnalysis(rnd),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(name, "type", "SPECIFIC_ANALYSIS"),
+// 					resource.TestCheckResourceAttr(name, "branch", "main"),
+// 					resource.TestCheckResourceAttr(name, "project", rnd),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccSonarqubeNewCodePeriodsBranchReferenceBranch(rnd string) string {
+	return fmt.Sprintf(`
+	    resource "sonarqube_project" "%[1]s" {
+			name = "%[1]s"
+			project = "%[1]s"
+			visibility = "public"
+		}
+
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			branch = "main"
+			project = sonarqube_project.%[1]s.project
+			type = "REFERENCE_BRANCH"
+			value = "development"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsBranchReferenceBranch(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsBranchReferenceBranch(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "REFERENCE_BRANCH"),
+					resource.TestCheckResourceAttr(name, "branch", "main"),
+					resource.TestCheckResourceAttr(name, "project", rnd),
+					resource.TestCheckResourceAttr(name, "value", "development"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeNewCodePeriodsProjectPreviousVersion(rnd string) string {
+	return fmt.Sprintf(`
+	    resource "sonarqube_project" "%[1]s" {
+			name = "%[1]s"
+			project = "%[1]s"
+			visibility = "public"
+		}
+
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			project = sonarqube_project.%[1]s.project
+			type = "PREVIOUS_VERSION"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsProjectPreviousVersion(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsProjectPreviousVersion(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "PREVIOUS_VERSION"),
+					resource.TestCheckResourceAttr(name, "project", rnd),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeNewCodePeriodsProjectNumberOfDays(rnd string) string {
+	return fmt.Sprintf(`
+	    resource "sonarqube_project" "%[1]s" {
+			name = "%[1]s"
+			project = "%[1]s"
+			visibility = "public"
+		}
+
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			project = sonarqube_project.%[1]s.project
+			type = "NUMBER_OF_DAYS"
+			value = "5"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsProjectNumberOfDays(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsProjectNumberOfDays(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "NUMBER_OF_DAYS"),
+					resource.TestCheckResourceAttr(name, "project", rnd),
+					resource.TestCheckResourceAttr(name, "value", "5"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeNewCodePeriodsProjectReferenceProject(rnd string) string {
+	return fmt.Sprintf(`
+	    resource "sonarqube_project" "%[1]s" {
+			name = "%[1]s"
+			project = "%[1]s"
+			visibility = "public"
+		}
+
+        resource "sonarqube_new_code_periods" "%[1]s" {
+			project = sonarqube_project.%[1]s.project
+			type = "REFERENCE_BRANCH"
+			value = "development"
+        }`, rnd)
+}
+
+func TestAccSonarqubeNewCodePeriodsProjectReferenceProject(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_new_code_periods." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeNewCodePeriodsProjectReferenceProject(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "type", "REFERENCE_BRANCH"),
+					resource.TestCheckResourceAttr(name, "project", rnd),
+					resource.TestCheckResourceAttr(name, "value", "development"),
+				),
+			},
+		},
+	})
+}

--- a/sonarqube/resource_sonarqube_new_code_periods_test.go
+++ b/sonarqube/resource_sonarqube_new_code_periods_test.go
@@ -152,18 +152,18 @@ func TestAccSonarqubeNewCodePeriodsBranchNumberOfDays(t *testing.T) {
 // 			project = "%[1]s"
 // 			visibility = "public"
 // 		}
-// 
+//
 //         resource "sonarqube_new_code_periods" "%[1]s" {
 // 			branch = "main"
 // 			project = sonarqube_project.%[1]s.project
 // 			type = "SPECIFIC_ANALYSIS"
 //         }`, rnd)
 // }
-// 
+//
 // func TestAccSonarqubeNewCodePeriodsBranchSpecificAnalysis(t *testing.T) {
 // 	rnd := generateRandomResourceName()
 // 	name := "sonarqube_new_code_periods." + rnd
-// 
+//
 // 	resource.Test(t, resource.TestCase{
 // 		PreCheck:  func() { testAccPreCheck(t) },
 // 		Providers: testAccProviders,


### PR DESCRIPTION
Some SonarQube projects need to use different settings for the basis of "new code" analysis (e.g.: previous version vs a reference branch). This adds support for configuring those settings through the [`/api/new_code_periods` APIs](https://next.sonarqube.com/sonarqube/web_api/api/new_code_periods).