### PR TITLE
Support Sonarqube portfolios

### DIFF
--- a/.github/workflows/acceptance-tests-lts.yml
+++ b/.github/workflows/acceptance-tests-lts.yml
@@ -33,6 +33,6 @@ jobs:
           SONAR_PASS: admin
     services:
       sonarqube:
-        image: sonarqube:lts-developer
+        image: sonarqube:enterprise
         ports:
           - 9000:9000

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -36,6 +36,6 @@ jobs:
         uses: codecov/codecov-action@v2
     services:
       sonarqube:
-        image: sonarqube:developer
+        image: sonarqube:enterprise
         ports:
           - 9000:9000

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 export TF_LOG=DEBUG
 SRC=$(shell find . -name '*.go')
-SONARQUBE_IMAGE?=sonarqube:lts
+SONARQUBE_IMAGE?=sonarqube:developer
 SONARQUBE_START_SLEEP?=60
 
 .PHONY: all vet build test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 export TF_LOG=DEBUG
 SRC=$(shell find . -name '*.go')
-SONARQUBE_IMAGE?=sonarqube:developer
+SONARQUBE_IMAGE?=sonarqube:lts
 SONARQUBE_START_SLEEP?=60
 
 .PHONY: all vet build test

--- a/docs/resources/sonarqube_portfolio.md
+++ b/docs/resources/sonarqube_portfolio.md
@@ -1,0 +1,35 @@
+# sonarqube_portfolio
+Provides a Sonarqube Portfolio resource. This can be used to create and manage Sonarqube Portfolio. Note that the SonarQube API for Portfolios is called ``views`` 
+
+## Example: create a portfolio
+```terraform
+resource "sonarqube_portfolio" "main" {
+    key         = "portfolio-key"
+    name        = "portfolio-name"
+    description = "portfolio-description"
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+
+- key - (Required) The key of the Portfolio to create
+- name - (Required) The name of the Portfolio to create
+- description - (Required) A description of the Portfolio to create
+- visibility - (Optional) Whether the created portfolio should be visible to everyone, or only specific user/groups. If no visibility is specified, the default portfolio visibility will be `public`.
+- selection_mode - (Optional) How to populate the Portfolio to create. Possible values are ``NONE``, ``MANUAL``, ``TAGS``, ``REGEXP`` or ``REST``. [See docs](https://docs.sonarqube.org/9.8/project-administration/managing-portfolios/#populating-portfolios) for how Portfolio population works
+- branch - (Optional) Which branch to analyze. If nothing is specified, the main branch is used. 
+- tags - (Optional) List of Project tags to populate the Portfolio from. Only active when `selection_mode` is `TAGS`
+- regexp - (Optional) A regular expression that is used to match Projects with a matching name OR key. If they match, they are added to the Portfolio
+
+## Attributes Reference
+The following attributes are exported in addition to the arguments above:
+- qualifier - (Computed) Key of the portfolio (`VW` for views)
+
+## Import 
+Portfolios can be imported using their portfolio key
+
+```terraform
+terraform import sonarqube_portfolio.main my_portfolio
+```
+

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -73,6 +73,7 @@ func Provider() *schema.Provider {
 			"sonarqube_plugin":                             resourceSonarqubePlugin(),
 			"sonarqube_project":                            resourceSonarqubeProject(),
 			"sonarqube_project_main_branch":                resourceSonarqubeProjectMainBranch(),
+			"sonarqube_portfolio":                          resourceSonarqubePortfolio(),
 			"sonarqube_qualityprofile":                     resourceSonarqubeQualityProfile(),
 			"sonarqube_qualityprofile_project_association": resourceSonarqubeQualityProfileProjectAssociation(),
 			"sonarqube_qualitygate":                        resourceSonarqubeQualityGate(),
@@ -95,6 +96,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"sonarqube_user":           dataSourceSonarqubeUser(),
 			"sonarqube_project":        dataSourceSonarqubeProject(),
+			"sonarqube_portfolio":      dataSourceSonarqubePortfolio(),
 			"sonarqube_qualityprofile": dataSourceSonarqubeQualityProfile(),
 			"sonarqube_rule":           dataSourceSonarqubeRule(),
 		},

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -96,7 +96,6 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"sonarqube_user":           dataSourceSonarqubeUser(),
 			"sonarqube_project":        dataSourceSonarqubeProject(),
-			"sonarqube_portfolio":      dataSourceSonarqubePortfolio(),
 			"sonarqube_qualityprofile": dataSourceSonarqubeQualityProfile(),
 			"sonarqube_rule":           dataSourceSonarqubeRule(),
 		},

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -1,0 +1,270 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Portfolio used in CreatePortfolioResponse
+type Portfolio struct {
+	Key       string `json:"key"`
+	Name      string `json:"name"`
+	Desc      string `json:"desc"`
+	Qualifier string `json:"qualifier"`
+	Visibility string `json:"visibility"`
+	SelectionMode string `json:"selectionMode"`
+}
+
+// CreatePortfolioResponse for unmarshalling response body of project creation
+type CreatePortfolioResponse struct {
+	Portfolio Portfolio `json:"portfolio"`
+}
+
+// GetPortfolio for unmarshalling response body of Portfolio get
+type GetPortfolio struct {
+	Portfolio Portfolio `json:"portfolio"`
+}
+
+
+// Returns the resource represented by this file.
+func resourceSonarqubePortfolio() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubePortfolioCreate,
+		Read:   resourceSonarqubePortfolioRead,
+		Update: resourceSonarqubePortfolioUpdate,
+		Delete: resourceSonarqubePortfoliotDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubePortfolioImport,
+		},
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"qualifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "public", // TODO: Not sure if this should be public. The docs makes it sound like this is a global setting somewhere
+				ForceNew: false, // TODO: Implement update
+			},
+			"selection_mode": {
+				Type:     schema.TypeString,
+				Optional: true, // TODO: Add extra call ic Create for when something other than "NONE" is specified
+				Default:  "NONE", 
+				ForceNew: false, // TODO: Implement update
+				// TODO: Set "regexp" if mode="REGEXP", otherwise create/update fails
+			},
+		},
+	}
+}
+
+func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeURL url.URL) error {
+	var endpoint string
+	switch selectionMode := d.Get("selection_mode"); selectionMode {
+	case "NONE":
+		endpoint = "/api/views/set_none_mode" 
+		sonarQubeURL.RawQuery = url.Values{
+			"portfolio":       []string{d.Get("key").(string)},
+		}.Encode()
+
+	case "MANUAL":
+		endpoint = "/api/views/set_manual_mode"
+		sonarQubeURL.RawQuery = url.Values{
+			"portfolio":       []string{d.Get("key").(string)},
+		}.Encode()
+		
+	case "TAGS":
+		endpoint = "/api/views/set_tags_mode"
+		sonarQubeURL.RawQuery = url.Values{
+			"portfolio":       []string{d.Get("key").(string)},
+			"tags":       []string{d.Get("tags").(string)}, // TODO: Support this, and validate csv and tags
+		}.Encode()
+
+	case "REGEXP":
+		endpoint = "/api/views/set_regexp_mode"
+		sonarQubeURL.RawQuery = url.Values{
+			"portfolio":       []string{d.Get("key").(string)},
+			"regexp":       []string{d.Get("regexp").(string)}, // TODO: Support this 
+		}.Encode()
+
+	case "REST":
+		endpoint = "/api/views/set_remaining_projects_mode"
+		sonarQubeURL.RawQuery = url.Values{
+			"portfolio":       []string{d.Get("key").(string)},
+		}.Encode()
+
+	default:
+		return fmt.Errorf("resourceSonarqubePortfolioCreate: selection_mode needs to be set to one of NONE, MANUAL, TAGS, REGEXP, REST")
+	}
+
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + endpoint
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubePortfolioCreate",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubePortfolioCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/views/create"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"description":       []string{d.Get("description").(string)},
+		"key":    []string{d.Get("key").(string)},
+		"name": []string{d.Get("name").(string)},
+		"visibility": []string{d.Get("visibility").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubePortfolioCreate",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	err = portfolioSetSelectionMode(d, m, sonarQubeURL)
+	if err != nil {
+		return err
+	}
+
+	// Decode response into struct
+	portfolioResponse := CreatePortfolioResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&portfolioResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePortfolioCreate: Failed to decode json into struct: %+v", err)
+	}
+
+	d.SetId(portfolioResponse.Portfolio.Key)
+	return resourceSonarqubePortfolioRead(d, m)
+}
+
+func resourceSonarqubePortfolioRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/views/show"
+	sonarQubeURL.RawQuery = url.Values{
+		"key": []string{d.Id()},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubePortfolioRead",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	portfolioReadResponse := GetPortfolio{}
+	err = json.NewDecoder(resp.Body).Decode(&portfolioReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePortfolioRead: Failed to decode json into struct: %+v", err)
+	}
+
+	d.SetId(portfolioReadResponse.Portfolio.Key)
+	d.Set("name", portfolioReadResponse.Portfolio.Name)
+	d.Set("qualifier", portfolioReadResponse.Portfolio.Qualifier)
+	d.Set("visibility", portfolioReadResponse.Portfolio.Visibility)
+	d.Set("selectionMode", portfolioReadResponse.Portfolio.SelectionMode)
+
+	return nil
+
+}
+
+func resourceSonarqubePortfolioUpdate(d *schema.ResourceData, m interface{}) error {
+
+	if d.HasChange("name") || d.HasChange("description") {
+		sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+		sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/views/update"
+		sonarQubeURL.RawQuery = url.Values{
+			"key":    []string{d.Id()},
+			"description": []string{d.Get("description").(string)},
+			"name": []string{d.Get("name").(string)},
+		}.Encode()
+
+		resp, err := httpRequestHelper(
+			m.(*ProviderConfiguration).httpClient,
+			"POST",
+			sonarQubeURL.String(),
+			http.StatusNoContent,
+			"resourceSonarqubePortfolioUpdate",
+		)
+		if err != nil {
+			return fmt.Errorf("error updating Sonarqube Portfolio Name and Description: %+v", err)
+		}
+		defer resp.Body.Close()
+
+	}
+
+
+	return resourceSonarqubeProjectRead(d, m)
+}
+
+func resourceSonarqubePortfolioDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/views/delete"
+	sonarQubeURL.RawQuery = url.Values{
+		"key": []string{d.Id()},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubePortfolioDelete",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubePortfolioImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceSonarqubeProjectRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -135,10 +135,14 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 		}
 
 		endpoint = "/api/views/set_tags_mode"
-		tags := []string{d.Get("tags").(string)}
+		
+		var tags []string
+		for _, v := range d.Get("tags").([]interface{}) {
+			tags = append(tags, fmt.Sprint(v))
+		}
 		tagsCSV := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(tags)), ","), "[]")
 		sonarQubeURL.RawQuery = url.Values{
-			"branch":    []string{d.Get("key").(string)},
+			"branch":    []string{d.Get("branch").(string)},
 			"portfolio": []string{d.Get("key").(string)},
 			"tags":      []string{tagsCSV},
 		}.Encode()
@@ -150,7 +154,7 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 
 		endpoint = "/api/views/set_regexp_mode"
 		sonarQubeURL.RawQuery = url.Values{
-			"branch":    []string{d.Get("key").(string)},
+			"branch":    []string{d.Get("branch").(string)},
 			"portfolio": []string{d.Get("key").(string)},
 			"regexp":    []string{d.Get("regexp").(string)},
 		}.Encode()
@@ -162,7 +166,7 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 
 		endpoint = "/api/views/set_remaining_projects_mode"
 		sonarQubeURL.RawQuery = url.Values{
-			"branch":    []string{d.Get("key").(string)},
+			"branch":    []string{d.Get("branch").(string)},
 			"portfolio": []string{d.Get("key").(string)},
 		}.Encode()
 

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -61,7 +61,7 @@ func resourceSonarqubePortfolio() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "public",
-				ForceNew: true, // I cant find an API endpoint for changing this, even though it's possible in the UI
+				ForceNew: true, // TODO: There currently isn't an API to update this in-place, even though it's possible in the UI 
 				ValidateFunc: func(val any, key string) (warns []string, errs []error) {
 					visibility := val.(string)
 					validOptions := []string{"public", "private"}
@@ -115,7 +115,7 @@ func resourceSonarqubePortfolio() *schema.Resource {
 }
 
 // Validate the regexp and tag fields if the corresponding selection_mode is chosen
-func validatePortfolioResource(d *schema.ResourceData) error { // TODO: Doc this
+func validatePortfolioResource(d *schema.ResourceData) error {
 	switch selectionMode := d.Get("selection_mode"); selectionMode {
 	case "NONE", "MANUAL", "REST":
 		return nil

--- a/sonarqube/resource_sonarqube_portfolio_test.go
+++ b/sonarqube/resource_sonarqube_portfolio_test.go
@@ -43,6 +43,22 @@ func testAccSonarqubePortfolioConfigSelectionMode(rnd string, key string, name s
 		`, rnd, key, name, description, visibility, selectionMode)
 }
 
+func testAccSonarqubePortfolioConfigSelectionModeTags(rnd string, key string, name string, description string, visibility string, selectionMode string, tags []string) string {
+	formattedTags := generateHCLList(tags)
+	return fmt.Sprintf(`
+		resource "sonarqube_portfolio" "%[1]s" {
+		  key       = "%[2]s"
+		  name    = "%[3]s"
+		  description = "%[4]s"
+		  visibility = "%[5]s"
+		  selection_mode = "%[6]s"
+		  tags = %[7]s
+
+		}
+		`, rnd, key, name, description, visibility, selectionMode, formattedTags)
+}
+
+
 
 func TestAccSonarqubePortfolioBasic(t *testing.T) {
 	rnd := generateRandomResourceName()
@@ -208,6 +224,39 @@ func TestAccSonarqubePortfolioSelectionModeManual(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
 					resource.TestCheckResourceAttr(name, "selection_mode", "MANUAL"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSonarqubePortfolioSelectionModeTags(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_portfolio." + rnd
+	tags := []string{"tag1", "tag2"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioConfigSelectionModeTags(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "testAccSonarqubePortfolioDescription", "public", "TAGS", tags),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "selection_mode", "TAGS"),
+					resource.TestCheckResourceAttr(name, "tags.0", tags[0]),
+					resource.TestCheckResourceAttr(name, "tags.1", tags[1]),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "selection_mode", "TAGS"),
+					resource.TestCheckResourceAttr(name, "tags.0", tags[0]),
+					resource.TestCheckResourceAttr(name, "tags.1", tags[1]),
 				),
 			},
 		},

--- a/sonarqube/resource_sonarqube_portfolio_test.go
+++ b/sonarqube/resource_sonarqube_portfolio_test.go
@@ -1,0 +1,215 @@
+package sonarqube
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("sonarqube_portfolio", &resource.Sweeper{
+		Name: "sonarqube_portfolio",
+		F:    testSweepSonarqubePortfolioSweeper,
+	})
+}
+
+// TODO: implement sweeper to clean up portfolio: https://www.terraform.io/docs/extend/testing/acceptance-tests/sweepers.html
+func testSweepSonarqubePortfolioSweeper(r string) error {
+	return nil
+}
+
+func testAccSonarqubePortfolioBasicConfig(rnd string, key string, name string, description string, visibility string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_portfolio" "%[1]s" {
+		  key       = "%[2]s"
+		  name    = "%[3]s"
+		  description = "%[4]s"
+		  visibility = "%[5]s"
+		}
+		`, rnd, key, name, description, visibility)
+}
+
+func testAccSonarqubePortfolioConfigSelectionMode(rnd string, key string, name string, description string, visibility string, selectionMode string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_portfolio" "%[1]s" {
+		  key       = "%[2]s"
+		  name    = "%[3]s"
+		  description = "%[4]s"
+		  visibility = "%[5]s"
+		  selection_mode = "%[6]s"
+		}
+		`, rnd, key, name, description, visibility, selectionMode)
+}
+
+
+func TestAccSonarqubePortfolioBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_portfolio." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "testAccSonarqubePortfolioDescription", "public"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubePortfolioName"),
+					resource.TestCheckResourceAttr(name, "qualifier", "VW"), // Qualifier for Portfolios seems to always be "VW" (views)
+					resource.TestCheckResourceAttr(name, "description", "testAccSonarqubePortfolioDescription"),
+					resource.TestCheckResourceAttr(name, "visibility", "public"),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubePortfolioName"),
+					resource.TestCheckResourceAttr(name, "description", "testAccSonarqubePortfolioDescription"),
+					resource.TestCheckResourceAttr(name, "visibility", "public"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSonarqubePortfolioNameUpdate(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_portfolio." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "oldName", "testAccSonarqubePortfolioDescription", "public"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "name", "oldName"),
+				),
+			},
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "newName", "testAccSonarqubePortfolioDescription", "public"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "name", "newName"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSonarqubePortfolioDescriptionUpdate(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_portfolio." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "oldDescription", "public"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "description", "oldDescription"),
+				),
+			},
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "newDescription", "public"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "description", "newDescription"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSonarqubePortfolioVisibilityUpdate(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_portfolio." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "testAccSonarqubePortfolioDescription", "public"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "visibility", "public"),
+				),
+			},
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "testAccSonarqubePortfolioDescription", "private"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "visibility", "private"),
+				),
+			},
+		},
+	})
+}
+
+
+func TestAccSonarqubePortfolioVisibilityError(t *testing.T) {
+	rnd := generateRandomResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioBasicConfig(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "testAccSonarqubePortfolioDescription", "badValue"),
+				ExpectError: regexp.MustCompile("Accepted values are .* for key .* got:"),
+			},
+		},
+	})
+}
+
+func TestAccSonarqubePortfolioSelectionModeError(t *testing.T) {
+	rnd := generateRandomResourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioConfigSelectionMode(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "testAccSonarqubePortfolioDescription", "public", "badValue"),
+				ExpectError: regexp.MustCompile("Accepted values are .* for key .* got:"),
+			},
+		},
+	})
+}
+
+func TestAccSonarqubePortfolioSelectionModeManual(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_portfolio." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePortfolioConfigSelectionMode(rnd, "testAccSonarqubePortfolioKey", "testAccSonarqubePortfolioName", "testAccSonarqubePortfolioDescription", "public", "MANUAL"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "selection_mode", "MANUAL"),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
+					resource.TestCheckResourceAttr(name, "selection_mode", "MANUAL"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
This PR introduces support for Portolios. Worth to note are the following:
* I have not implemented the option for `MANUAL` portfolios to add projects via terraform
    * This PR is big as is. I'd rather do it later in that case. I'll work on it when I get the time if you want that functionality in this PR though
* `func validatePortfolioResource`
    * I implemented this as a validator for `REGEXP` and `TAGS` portfolios so that we don't end up in Terraform limbo, where the portfolio is created, but setting the mode fails. There might be cleaner ways of solving it, but I think it's fine
    * This function is called in the beginning of the `Create` and `Update` calls
* For some unholy reason only `sonarqube:enterprise` have support for portfolios. I'll let you @jdamata decide how you wanna handle CI for this. I don't know if it would be against their license modle to use the `enterprise` image for testing purposes
    * [Proof that it works on `enterprise` image](https://github.com/felixlut/terraform-provider-sonarqube/actions/runs/4516177445/jobs/7954234580)

Resolves #140 