### PR TITLE
Fix Portfolio default branch bug

### DIFF
--- a/docs/resources/sonarqube_portfolio.md
+++ b/docs/resources/sonarqube_portfolio.md
@@ -18,7 +18,7 @@ The following arguments are supported:
 - description - (Required) A description of the Portfolio to create
 - visibility - (Optional) Whether the created portfolio should be visible to everyone, or only specific user/groups. If no visibility is specified, the default portfolio visibility will be `public`.
 - selection_mode - (Optional) How to populate the Portfolio to create. Possible values are ``NONE``, ``MANUAL``, ``TAGS``, ``REGEXP`` or ``REST``. [See docs](https://docs.sonarqube.org/9.8/project-administration/managing-portfolios/#populating-portfolios) for how Portfolio population works
-- branch - (Optional) Which branch to analyze. If nothing is specified, the main branch is used. 
+- branch - (Optional) Which branch to analyze. If nothing, or "" is specified, the main branch is used.
 - tags - (Optional) List of Project tags to populate the Portfolio from. Only active when `selection_mode` is `TAGS`
 - regexp - (Optional) A regular expression that is used to match Projects with a matching name OR key. If they match, they are added to the Portfolio
 

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -74,7 +74,7 @@ func resourceSonarqubePortfolio() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Description: "Which branch to analyze. If nothing, or \"\" is specified, the main branch is used.",
+				Description: "Which branch to analyze. If nothing, or '' is specified, the main branch is used.",
 			},
 			"tags": { // Only active for TAGS
 				Type:          schema.TypeList,

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -192,10 +192,18 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 
 	case "REST":
 		endpoint = "/api/views/set_remaining_projects_mode"
-		sonarQubeURL.RawQuery = url.Values{
-			"branch":    []string{d.Get("branch").(string)},
+
+		urlParameters := url.Values{
 			"portfolio": []string{d.Get("key").(string)},
-		}.Encode()
+		}
+
+		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: TODO: Add Link to PR
+		branch := d.Get("branch").(string)
+		if len(branch) > 0 {
+			urlParameters.Add("branch", branch)
+		}
+
+		sonarQubeURL.RawQuery = urlParameters.Encode()
 
 	default:
 		return fmt.Errorf("resourceSonarqubePortfolioCreate: selection_mode needs to be set to one of NONE, MANUAL, TAGS, REGEXP, REST")

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -167,7 +167,7 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 			"tags":      []string{tagsCSV},
 		}
 
-		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: TODO: Add Link to PR
+		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: https://github.com/jdamata/terraform-provider-sonarqube/pull/150
 		branch := d.Get("branch").(string)
 		if len(branch) > 0 {
 			urlParameters.Add("branch", branch)
@@ -183,7 +183,7 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 			"regexp":    []string{d.Get("regexp").(string)},
 		}
 
-		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: TODO: Add Link to PR
+		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: https://github.com/jdamata/terraform-provider-sonarqube/pull/150
 		branch := d.Get("branch").(string)
 		if len(branch) > 0 {
 			urlParameters.Add("branch", branch)
@@ -198,7 +198,7 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 			"portfolio": []string{d.Get("key").(string)},
 		}
 
-		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: TODO: Add Link to PR
+		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: https://github.com/jdamata/terraform-provider-sonarqube/pull/150
 		branch := d.Get("branch").(string)
 		if len(branch) > 0 {
 			urlParameters.Add("branch", branch)

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -313,7 +313,7 @@ func resourceSonarqubePortfolioRead(d *schema.ResourceData, m interface{}) error
 	d.Set("visibility", portfolioReadResponse.Visibility)
 	d.Set("selection_mode", portfolioReadResponse.SelectionMode)
 
-	// These fields may or may not be set in the reposnse from SonarQube depending on the selection_mode
+	// These fields may or may not be set in the reposnse from SonarQube
 	if len(portfolioReadResponse.Tags) > 0 {
 		d.Set("tags", portfolioReadResponse.Tags)
 	}

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -74,6 +74,7 @@ func resourceSonarqubePortfolio() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
+				Description: "Which branch to analyze. If nothing, or \"\" is specified, the main branch is used.",
 			},
 			"tags": { // Only active for TAGS
 				Type:          schema.TypeList,
@@ -166,7 +167,7 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 			"tags":      []string{tagsCSV},
 		}
 
-		// SonarQube handles "" like it actually is a name of a branch
+		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: TODO: Add Link to PR
 		branch := d.Get("branch").(string)
 		if len(branch) > 0 {
 			urlParameters.Add("branch", branch)

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -160,19 +160,35 @@ func portfolioSetSelectionMode(d *schema.ResourceData, m interface{}, sonarQubeU
 			tags = append(tags, fmt.Sprint(v))
 		}
 		tagsCSV := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(tags)), ","), "[]")
-		sonarQubeURL.RawQuery = url.Values{
-			"branch":    []string{d.Get("branch").(string)},
+
+		urlParameters := url.Values{
 			"portfolio": []string{d.Get("key").(string)},
 			"tags":      []string{tagsCSV},
-		}.Encode()
+		}
+
+		// SonarQube handles "" like it actually is a name of a branch
+		branch := d.Get("branch").(string)
+		if len(branch) > 0 {
+			urlParameters.Add("branch", branch)
+		}
+
+		sonarQubeURL.RawQuery = urlParameters.Encode()
 
 	case "REGEXP":
 		endpoint = "/api/views/set_regexp_mode"
-		sonarQubeURL.RawQuery = url.Values{
-			"branch":    []string{d.Get("branch").(string)},
+
+		urlParameters := url.Values{
 			"portfolio": []string{d.Get("key").(string)},
 			"regexp":    []string{d.Get("regexp").(string)},
-		}.Encode()
+		}
+
+		// SonarQube handles "" like it actually is a name of a branch, see PR for reference: TODO: Add Link to PR
+		branch := d.Get("branch").(string)
+		if len(branch) > 0 {
+			urlParameters.Add("branch", branch)
+		}
+
+		sonarQubeURL.RawQuery = urlParameters.Encode()
 
 	case "REST":
 		endpoint = "/api/views/set_remaining_projects_mode"
@@ -287,11 +303,16 @@ func resourceSonarqubePortfolioRead(d *schema.ResourceData, m interface{}) error
 	d.Set("qualifier", portfolioReadResponse.Qualifier)
 	d.Set("visibility", portfolioReadResponse.Visibility)
 	d.Set("selection_mode", portfolioReadResponse.SelectionMode)
-	d.Set("branch", portfolioReadResponse.Branch)
-	d.Set("regexp", portfolioReadResponse.Regexp)
 
+	// These fields may or may not be set in the reposnse from SonarQube depending on the selection_mode
 	if len(portfolioReadResponse.Tags) > 0 {
 		d.Set("tags", portfolioReadResponse.Tags)
+	}
+	if len(portfolioReadResponse.Branch) > 0 {
+		d.Set("branch", portfolioReadResponse.Branch)
+	}
+	if len(portfolioReadResponse.Regexp) > 0 {
+		d.Set("regexp", portfolioReadResponse.Regexp)
 	}
 
 	return nil

--- a/sonarqube/resource_sonarqube_portfolio_test.go
+++ b/sonarqube/resource_sonarqube_portfolio_test.go
@@ -290,6 +290,7 @@ func TestAccSonarqubePortfolioSelectionModeTags(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "selection_mode", "TAGS"),
 					resource.TestCheckResourceAttr(name, "tags.0", tags[0]),
 					resource.TestCheckResourceAttr(name, "tags.1", tags[1]),
+					resource.TestCheckNoResourceAttr(name, "branch"),
 				),
 			},
 			{
@@ -301,6 +302,7 @@ func TestAccSonarqubePortfolioSelectionModeTags(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "selection_mode", "TAGS"),
 					resource.TestCheckResourceAttr(name, "tags.0", tags[0]),
 					resource.TestCheckResourceAttr(name, "tags.1", tags[1]),
+					resource.TestCheckNoResourceAttr(name, "branch"),
 				),
 			},
 		},
@@ -321,6 +323,7 @@ func TestAccSonarqubePortfolioSelectionModeRegexp(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
 					resource.TestCheckResourceAttr(name, "selection_mode", "REGEXP"),
 					resource.TestCheckResourceAttr(name, "regexp", "regexp1"),
+					resource.TestCheckNoResourceAttr(name, "branch"),
 				),
 			},
 			{
@@ -331,6 +334,7 @@ func TestAccSonarqubePortfolioSelectionModeRegexp(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubePortfolioKey"),
 					resource.TestCheckResourceAttr(name, "selection_mode", "REGEXP"),
 					resource.TestCheckResourceAttr(name, "regexp", "regexp1"),
+					resource.TestCheckNoResourceAttr(name, "branch"),
 				),
 			},
 		},
@@ -359,6 +363,7 @@ func TestAccSonarqubePortfolioSelectionModeUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "selection_mode", "TAGS"),
 					resource.TestCheckResourceAttr(name, "tags.0", tags[0]),
 					resource.TestCheckResourceAttr(name, "tags.1", tags[1]),
+					resource.TestCheckNoResourceAttr(name, "branch"),
 				),
 			},
 			{
@@ -370,6 +375,7 @@ func TestAccSonarqubePortfolioSelectionModeUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "selection_mode", "TAGS"),
 					resource.TestCheckResourceAttr(name, "tags.0", tags[0]),
 					resource.TestCheckResourceAttr(name, "tags.1", tags[1]),
+					resource.TestCheckNoResourceAttr(name, "branch"),
 				),
 			},
 		},


### PR DESCRIPTION
When you create a Portfolio in `TAGS`, `REGEX` or `REST` mode without specifying a `branch`, the Portfolio should pick the default branch (or as [SonarQube calls it](https://docs.sonarqube.org/9.7/analyzing-source-code/branches/branch-analysis/#main-branch), "Main Branch") of the Project. When setting the mode via the API, an optional parameter `branch` can be used for this purpose. If it's left unset, then the Portfolio will pick the default branch of the project, but setting it to `""` does not yield the same result as one might expect. 

This PR fixes that by only appending the `branch` parameter when it is actually set in the `Terraform` resource.

Calling the API, we can see that this Portfolio, which does not pick up the default branch of its projects, and was created with the provider without setting the `branch` in the resource, still set `branch` to `""` via the `api/views/show?key=on-prem` endpoint:
![bild](https://user-images.githubusercontent.com/34520175/229276921-df3bbee7-dcf7-457a-af1b-4942329ca743.png)

With this update, the resulting Portfolio looks like this instead:
![bild](https://user-images.githubusercontent.com/34520175/229277193-3552597c-7167-4cd3-a224-f8118209d0e9.png)
