### PR TITLE
Run tests on lts version

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_tag: [community, developer, enterprise]
+        image_tag: [lts-community, lts-developer, lts-enterprise]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
SonarQube just released their new version, and changed the way the [Docker tags](https://hub.docker.com/_/sonarqube) are referenced. Without the `lts` prefix, the tests are running against version 10. Probably why #149 is failing too