### PR TITLE
fix(group): fix broken code with deprecated group API from 10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 export TF_LOG=DEBUG
 SRC=$(shell find . -name '*.go')
-SONARQUBE_IMAGE?=sonarqube:developer
+SONARQUBE_IMAGE?=sonarqube:lts-developer
 SONARQUBE_START_SLEEP?=60
 
 .PHONY: all vet build test

--- a/docs/resources/sonarqube_group.md
+++ b/docs/resources/sonarqube_group.md
@@ -26,7 +26,7 @@ The following attributes are exported:
 
 ## Import
 
-Groups can be imported using their ID
+Groups can be imported using their ID, and only support in the Sonarqube version <= 9.9
 
 ```terraform
 terraform import sonarqube_group.group 101

--- a/sonarqube/resource_sonarqube_group.go
+++ b/sonarqube/resource_sonarqube_group.go
@@ -117,10 +117,8 @@ func resourceSonarqubeGroupRead(d *schema.ResourceData, m interface{}) error {
 	}
 	// Loop over all groups to see if the group we need exists.
 	for _, value := range groupReadResponse.Groups {
-		if d.Id() == value.ID {
+		if d.Get("name").(string) == value.Name {
 			// If it does, set the values of that group
-			d.SetId(value.ID)
-			d.Set("name", value.Name)
 			d.Set("description", value.Description)
 			readSuccess = true
 		}

--- a/sonarqube/resource_sonarqube_group.go
+++ b/sonarqube/resource_sonarqube_group.go
@@ -172,7 +172,7 @@ func resourceSonarqubeGroupDelete(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_groups/delete"
 
 	sonarQubeURL.RawQuery = url.Values{
-		"id": []string{d.Id()},
+		"name": []string{d.Get("name").(string)},
 	}.Encode()
 
 	resp, err := httpRequestHelper(

--- a/sonarqube/resource_sonarqube_group.go
+++ b/sonarqube/resource_sonarqube_group.go
@@ -48,7 +48,6 @@ func resourceSonarqubeGroup() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -139,8 +138,10 @@ func resourceSonarqubeGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/user_groups/update"
 
+	oldName, newName := d.GetChange("name")
 	rawQuery := url.Values{
-		"id": []string{d.Id()},
+		"currentName": []string{oldName.(string)},
+		"name":        []string{newName.(string)},
 	}
 
 	if _, ok := d.GetOk("description"); ok {

--- a/sonarqube/resource_sonarqube_group_test.go
+++ b/sonarqube/resource_sonarqube_group_test.go
@@ -64,8 +64,8 @@ func TestAccSonarqubeGroupBasic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", groupName),
-					resource.TestCheckResourceAttr(name, "description", "group description"),
+					resource.TestCheckResourceAttr(name, "name", updatedGroupName),
+					resource.TestCheckResourceAttr(name, "description", "group description 3"),
 				),
 			},
 		},

--- a/sonarqube/resource_sonarqube_group_test.go
+++ b/sonarqube/resource_sonarqube_group_test.go
@@ -31,23 +31,32 @@ func testAccSonarqubeGroupBasicConfig(rnd string, name string, description strin
 func TestAccSonarqubeGroupBasic(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "sonarqube_group." + rnd
+	groupName := "testAccSonarqubeGroup" + rnd
+	updatedGroupName := "testAccSonarqubeGroupUpdated" + rnd
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSonarqubeGroupBasicConfig(rnd, "testAccSonarqubeGroup", "group description"),
+				Config: testAccSonarqubeGroupBasicConfig(rnd, groupName, "group description"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeGroup"),
+					resource.TestCheckResourceAttr(name, "name", groupName),
 					resource.TestCheckResourceAttr(name, "description", "group description"),
 				),
 			},
 			{
-				Config: testAccSonarqubeGroupBasicConfig(rnd, "testAccSonarqubeGroup", "group description 2"),
+				Config: testAccSonarqubeGroupBasicConfig(rnd, groupName, "group description 2"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeGroup"),
+					resource.TestCheckResourceAttr(name, "name", groupName),
 					resource.TestCheckResourceAttr(name, "description", "group description 2"),
+				),
+			},
+			{
+				Config: testAccSonarqubeGroupBasicConfig(rnd, updatedGroupName, "group description 3"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", updatedGroupName),
+					resource.TestCheckResourceAttr(name, "description", "group description 3"),
 				),
 			},
 			{
@@ -55,7 +64,7 @@ func TestAccSonarqubeGroupBasic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeGroup"),
+					resource.TestCheckResourceAttr(name, "name", groupName),
 					resource.TestCheckResourceAttr(name, "description", "group description"),
 				),
 			},


### PR DESCRIPTION
**Why**

Related to https://github.com/jdamata/terraform-provider-sonarqube/issues/152, and` there is a breaking change from Sonarqube 10`, that in the [group API since 10.0](https://next.sonarqube.com/sonarqube/web_api/api/user_groups), no ID in the request or response body

<img width="541" alt="Screenshot 2023-04-15 at 17 31 19" src="https://user-images.githubusercontent.com/759107/232238285-dd6eadd3-e435-48cc-a431-49936d100104.png">

below is the test response to sonarqube 10:

```
  curl -x "" https://xxx:@sq.test.com/api/user_groups/search\?q\=Project-Users-6 | jq .          

{
  "paging": {
    "pageIndex": 1,
    "pageSize": 100,
    "total": 1
  },
  "groups": [
    {
      "name": "Project-Users-6",
      "description": "This is a group 6",
      "membersCount": 0,
      "default": false,
      "managed": false
    }
  ]
}
```

so created this fix to make sonarqube_group resource to be compatible to support both ID and Name operations.

**Changes**

* Compared name in Read, Update, Delete methods, and to make it compatible with version LTS 9.9 and 10.0+
* Removed forceNew for name update, [because the new API supports to update name in-place](https://next.sonarqube.com/sonarqube/web_api/api/user_groups/update)
* Changed local acctest to use the same version as the one in the github action pipeline

**Test**

* Tested in my local
* Passed the acc test