### PR TITLE
sonarqube_qualitygate should populate the conditions property

### DIFF
--- a/sonarqube/helper_test.go
+++ b/sonarqube/helper_test.go
@@ -3,8 +3,13 @@ package sonarqube
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"strings"
 
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 )
 
@@ -28,4 +33,28 @@ func generateHCLMap(m map[string]string) string {
 	b.Truncate(b.Len() - 2)
 	fmt.Fprintf(b, "}")
 	return b.String()
+}
+
+// Returns the version of SonarQube running on the instance the tests are running against
+func getSonarQubeVersion() (*version.Version, error) {
+	sonarQubeURL := strings.TrimSuffix(os.Getenv("SONAR_HOST"), "/") + "/api/server/version"
+
+	resp, err := httpRequestHelper(
+		retryablehttp.NewClient(),
+		"GET",
+		sonarQubeURL,
+		http.StatusOK,
+		"api/server",
+	)
+	if err != nil {
+		return &version.Version{}, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &version.Version{}, err
+	}
+	version, _ := version.NewVersion(string(bodyBytes))
+	return version, nil
 }

--- a/sonarqube/resource_sonarqube_qualitygate.go
+++ b/sonarqube/resource_sonarqube_qualitygate.go
@@ -244,10 +244,11 @@ func setDefaultQualityGate(d *schema.ResourceData, m interface{}, setDefault boo
 }
 
 func flattenReadQualityGateConditionsResponse(input *[]ReadQualityGateConditionsResponse) []interface{} {
-	flatConditions := make([]interface{}, len(*input), len(*input))
-	if input == nil {
-		return flatConditions
+	if input == nil || len(*input) == 0 {
+		return make([]interface{}, 0)
 	}
+
+	flatConditions := make([]interface{}, len(*input))
 
 	for i, condition := range *input {
 		c := make(map[string]interface{})

--- a/sonarqube/resource_sonarqube_qualitygate.go
+++ b/sonarqube/resource_sonarqube_qualitygate.go
@@ -91,7 +91,7 @@ func resourceSonarqubeQualityGate() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"error": {
+						"threshold": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -256,7 +256,7 @@ func flattenReadQualityGateConditionsResponse(input *[]ReadQualityGateConditions
 		c["id"] = condition.ID
 		c["metric"] = condition.Metric
 		c["op"] = condition.OP
-		c["error"] = condition.Error
+		c["threshold"] = condition.Error
 
 		flatConditions[i] = c
 	}


### PR DESCRIPTION
Fixes https://github.com/jdamata/terraform-provider-sonarqube/issues/156

If you apply the fix but don't update the test then:
* Running against SonarQube `9.8` and below there will be no change and the tests will pass
* Running against SonarQube `9.9` and above, the relevant test will fail

Updating the test will allow it to pass successfully with either version