### PR TITLE
When deleting a quality gate, only change the default if the one you are deleting is currently default.

### DIFF
--- a/sonarqube/resource_sonarqube_qualitygate.go
+++ b/sonarqube/resource_sonarqube_qualitygate.go
@@ -196,6 +196,14 @@ func resourceSonarqubeQualityGateDelete(d *schema.ResourceData, m interface{}) e
 		"name": []string{d.Id()},
 	}.Encode()
 
+	// If this is the default quality gate then we need to default it back to "Sonar way" so there is still a default
+	if d.Get("is_default").(bool) {
+		err := setDefaultQualityGate(d, m, false)
+		if err != nil {
+			return err
+		}
+	}
+	
 	err := setDefaultQualityGate(d, m, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/jdamata/terraform-provider-sonarqube/issues/158

* If you are deleting a non-default quality gate then whatever is currently default should stay as such
* If you are deleting the default gate then set the new default to the built in "Sonar way" which cannot be deleted.

Tested with the following resources:
```hcl
resource "sonarqube_qualitygate" "way" {
  name       = "My way"
  is_default = true
}

resource "sonarqube_qualitygate" "other" {
  name       = "My Other way"
}
```
"My way" was set to default

Changed to
```hcl
resource "sonarqube_qualitygate" "way" {
  name       = "My way"
}

resource "sonarqube_qualitygate" "other" {
  name       = "My Other way"
  is_default = true
}
```
"My Other way" was set to default

Changed to:
```hcl
resource "sonarqube_qualitygate" "other" {
  name       = "My Other way"
  is_default = true
}
```

"My way" was deleted and "My Other way" continued to be the default

Finally removed "My Other way" from the terraform script and ran again.
"My Other way" was deleted and "Sonar way" was set as the default