### PR TITLE
fixes sonarqube_group for SonarQube 10.0

### DIFF
--- a/sonarqube/resource_sonarqube_group.go
+++ b/sonarqube/resource_sonarqube_group.go
@@ -121,10 +121,12 @@ func resourceSonarqubeGroupRead(d *schema.ResourceData, m interface{}) error {
 	// Loop over all groups to see if the group we need exists.
 	for _, value := range groupReadResponse.Groups {
 		// no ID in the group search response from sonarqube 10.0+,
-		// here is to make comparation compatible with sonarqube 9.9 and 10+
+		// here is to make comparison compatible with sonarqube 9.9 and 10+
 		if (d.Id() != "" && d.Id() == value.ID) || groupName == value.Name {
 			if value.ID != "" {
 				d.SetId(value.ID)
+			} else {
+				//				d.SetId(value.Name)
 			}
 			// If it does, set the values of that group
 			d.Set("name", value.Name)
@@ -136,7 +138,9 @@ func resourceSonarqubeGroupRead(d *schema.ResourceData, m interface{}) error {
 
 	if !readSuccess {
 		// Group not found
-		d.SetId("")
+		if _, ok := d.GetOk("id"); ok {
+			d.SetId("")
+		}
 	}
 
 	return nil

--- a/sonarqube/resource_sonarqube_group.go
+++ b/sonarqube/resource_sonarqube_group.go
@@ -125,8 +125,6 @@ func resourceSonarqubeGroupRead(d *schema.ResourceData, m interface{}) error {
 		if (d.Id() != "" && d.Id() == value.ID) || groupName == value.Name {
 			if value.ID != "" {
 				d.SetId(value.ID)
-			} else {
-				//				d.SetId(value.Name)
 			}
 			// If it does, set the values of that group
 			d.Set("name", value.Name)

--- a/sonarqube/resource_sonarqube_group_test.go
+++ b/sonarqube/resource_sonarqube_group_test.go
@@ -32,6 +32,27 @@ func TestAccSonarqubeGroupBasic(t *testing.T) {
 	rnd := generateRandomResourceName()
 	name := "sonarqube_group." + rnd
 	groupName := "testAccSonarqubeGroup" + rnd
+	groupDescription := "testAccSonarqubeDescription" + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeGroupBasicConfig(rnd, groupName, groupDescription),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "name", groupName),
+					resource.TestCheckResourceAttr(name, "description", groupDescription),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSonarqubeGroupUpdate(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_group." + rnd
+	groupName := "testAccSonarqubeGroup" + rnd
 	updatedGroupName := "testAccSonarqubeGroupUpdated" + rnd
 
 	resource.Test(t, resource.TestCase{
@@ -59,13 +80,29 @@ func TestAccSonarqubeGroupBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "description", "group description 3"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccSonarqubeGroupImport(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_group." + rnd
+	groupName := "testAccSonarqubeGroup" + rnd
+	groupDescription := "testAccSonarqubeGroupDescription" + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
-				ResourceName:      name,
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: testAccSonarqubeGroupBasicConfig(rnd, groupName, groupDescription),
+			},
+			{
+				ResourceName: name,
+				ImportState:  true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "name", updatedGroupName),
-					resource.TestCheckResourceAttr(name, "description", "group description 3"),
+					resource.TestCheckResourceAttr(name, "name", groupName),
+					resource.TestCheckResourceAttr(name, "description", groupDescription),
 				),
 			},
 		},


### PR DESCRIPTION
This should fix the other issue reported in https://github.com/jdamata/terraform-provider-sonarqube/issues/162: `Error: The provider returned a resource missing an identifier during ImportResourceState.` 

If you merge this, can you re-run the acceptance tests on https://github.com/jdamata/terraform-provider-sonarqube/pull/161 to confirm this issue has gone.

Once you merge this and https://github.com/jdamata/terraform-provider-sonarqube/pull/164, you should be able to merge https://github.com/jdamata/terraform-provider-sonarqube/issues/162