### PR TITLE
Adds Azure DevOps ALM and Binding

### DIFF
--- a/docs/resources/sonarqube_alm_azure.md
+++ b/docs/resources/sonarqube_alm_azure.md
@@ -1,0 +1,29 @@
+# sonarqube_alm_azure
+
+Provides a Sonarqube Azure Devops Alm/Devops Platform Integration resource. This can be used to create and manage a Alm/Devops
+Platform Integration for Azure Devops.
+
+## Example: Create an Azure Devops Alm Integration
+
+```terraform
+resource "sonarqube_alm_azure" "az1" {
+  key                   = "az1"
+  personal_access_token = "my_pat"
+  url                   = "https://dev.azure.com/my-org"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- key - (Required) - Unique key of the azure alm instance setting. Maximum length: 200
+- personal_access_token - (Required) - Azure Devops Personal Access Token. Maximum length: 2000
+- url - (Required) - Azure Devops Organization URL. Maximum length: 2000
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- key - The unique key of the azure alm instance setting.
+- url - Azure Devops Organization URL.

--- a/docs/resources/sonarqube_alm_azure.md
+++ b/docs/resources/sonarqube_alm_azure.md
@@ -27,3 +27,11 @@ The following attributes are exported:
 
 - key - The unique key of the azure alm instance setting.
 - url - Azure Devops Organization URL.
+
+## Import
+
+Resource can be imported providing their Alm Instance Key and Azure DevOps Personal Access Token
+
+```terraform
+terraform import sonarqube_alm_azure.az1 key/personal_access_token
+```

--- a/docs/resources/sonarqube_azure_binding.md
+++ b/docs/resources/sonarqube_azure_binding.md
@@ -1,0 +1,51 @@
+# sonarqube_azure_binding
+
+Provides a Sonarqube Azure Devops binding resource. This can be used to create and manage the binding between an
+Azure Devops repository and a SonarQube project
+
+## Example: Create an Azure Devops binding
+
+```terraform
+resource "sonarqube_alm_azure" "az1" {
+  key           = "az1"
+  personal_access_token    = "my_pat"
+  url           = "https://dev.azure.com/my-org"
+}
+
+resource "sonarqube_project" "main" {
+  name       = "SonarQube"
+  project    = "my_project"
+  visibility = "public"
+}
+
+resource "sonarqube_azure_binding" "az1-my_project-my_repo" {
+  alm_setting = sonarqube_alm_azure.az1.key
+  project    = sonarqube_project.main.project
+  repository = "my_repo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- alm_setting - (Required) - azure ALM setting key
+- monorepo - (Optional) - Is this project part of a monorepo. Default value: false
+- project - (Required) - Project key
+- repository - (Required) - The name of your Azure Devops repository.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- project - Project key.
+- repository - Azure Devops Repository.
+- alm_setting - The unique key of the azure alm instance setting.
+
+## Import
+
+Bindings can be imported using their ID
+
+```terraform
+terraform import sonarqube_azure_binding.az1-my_project-my_repo project/repository
+```

--- a/docs/resources/sonarqube_azure_binding.md
+++ b/docs/resources/sonarqube_azure_binding.md
@@ -19,10 +19,10 @@ resource "sonarqube_project" "main" {
 }
 
 resource "sonarqube_azure_binding" "main" {
-  alm_setting   = sonarqube_alm_azure.az1.key
-  project       = sonarqube_project.main.project
-  project_name  = "my_azure_project"
-  repository    = "my_repo"
+  alm_setting     = sonarqube_alm_azure.az1.key
+  project         = sonarqube_project.main.project
+  project_name    = "my_azure_project"
+  repository_name = "my_repo"
 }
 ```
 
@@ -34,16 +34,16 @@ The following arguments are supported:
 - monorepo - (Optional) - Is this project part of a monorepo. Default value: false
 - project - (Required) - SonarQube Project key
 - project_name - (Required) - Azure DevOps Project name
-- repository - (Required) - Azure DevOps Repository name
+- repository_name - (Required) - Azure DevOps Repository name
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 - alm_setting - The unique key of the azure alm instance setting.
-- project - Project key.
+- project - SonarQube Project key.
 - project_name - Azure DevOps Project name.
-- repository - Azure DevOps Repository name.
+- repository_name - Azure DevOps Repository name.
 
 ## Import
 

--- a/docs/resources/sonarqube_azure_binding.md
+++ b/docs/resources/sonarqube_azure_binding.md
@@ -7,21 +7,22 @@ Azure Devops repository and a SonarQube project
 
 ```terraform
 resource "sonarqube_alm_azure" "az1" {
-  key           = "az1"
-  personal_access_token    = "my_pat"
-  url           = "https://dev.azure.com/my-org"
+  key                   = "az1"
+  personal_access_token = "my_pat"
+  url                   = "https://dev.azure.com/my-org"
 }
 
 resource "sonarqube_project" "main" {
   name       = "SonarQube"
-  project    = "my_project"
+  project    = "main"
   visibility = "public"
 }
 
-resource "sonarqube_azure_binding" "az1-my_project-my_repo" {
-  alm_setting = sonarqube_alm_azure.az1.key
-  project    = sonarqube_project.main.project
-  repository = "my_repo"
+resource "sonarqube_azure_binding" "main" {
+  alm_setting   = sonarqube_alm_azure.az1.key
+  project       = sonarqube_project.main.project
+  project_name  = "my_azure_project"
+  repository    = "my_repo"
 }
 ```
 
@@ -31,21 +32,23 @@ The following arguments are supported:
 
 - alm_setting - (Required) - azure ALM setting key
 - monorepo - (Optional) - Is this project part of a monorepo. Default value: false
-- project - (Required) - Project key
-- repository - (Required) - The name of your Azure Devops repository.
+- project - (Required) - SonarQube Project key
+- project_name - (Required) - Azure DevOps Project name
+- repository - (Required) - Azure DevOps Repository name
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-- project - Project key.
-- repository - Azure Devops Repository.
 - alm_setting - The unique key of the azure alm instance setting.
+- project - Project key.
+- project_name - Azure DevOps Project name.
+- repository - Azure DevOps Repository name.
 
 ## Import
 
 Bindings can be imported using their ID
 
 ```terraform
-terraform import sonarqube_azure_binding.az1-my_project-my_repo project/repository
+terraform import sonarqube_azure_binding.main project/project_name/repository
 ```

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -74,6 +74,8 @@ func Provider() *schema.Provider {
 		},
 		// Add the resources supported by this provider to this map.
 		ResourcesMap: map[string]*schema.Resource{
+			"sonarqube_alm_azure":                          resourceSonarqubeAlmAzure(),
+			"sonarqube_azure_binding":                      resourceSonarqubeAzureBinding(),
 			"sonarqube_group":                              resourceSonarqubeGroup(),
 			"sonarqube_group_member":                       resourceSonarqubeGroupMember(),
 			"sonarqube_permission_template":                resourceSonarqubePermissionTemplate(),

--- a/sonarqube/resource_sonarqube_alm_azure.go
+++ b/sonarqube/resource_sonarqube_alm_azure.go
@@ -86,7 +86,6 @@ func resourceSonarqubeAlmAzureCreate(d *schema.ResourceData, m interface{}) erro
 func resourceSonarqubeAlmAzureRead(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/list_definitions"
-	sonarQubeURL.RawQuery = url.Values{}.Encode() // Dunno if you can keep it empty tbh?
 
 	resp, err := httpRequestHelper(
 		m.(*ProviderConfiguration).httpClient,

--- a/sonarqube/resource_sonarqube_alm_azure.go
+++ b/sonarqube/resource_sonarqube_alm_azure.go
@@ -33,10 +33,10 @@ func resourceSonarqubeAlmAzure() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"personalAccessToken": {
+			"personal_access_token": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Required: false,
+				ForceNew: false,
 			},
 			"url": {
 				Type:     schema.TypeString,
@@ -113,6 +113,7 @@ func resourceSonarqubeAlmAzureUpdate(d *schema.ResourceData, m interface{}) erro
 	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/update_azure"
 	sonarQubeURL.RawQuery = url.Values{
 		"key":                 []string{d.Id()},
+		"newKey":              []string{d.Get("key").(string)},
 		"personalAccessToken": []string{d.Get("personal_access_token").(string)},
 		"url":                 []string{d.Get("url").(string)},
 	}.Encode()

--- a/sonarqube/resource_sonarqube_alm_azure.go
+++ b/sonarqube/resource_sonarqube_alm_azure.go
@@ -1,0 +1,155 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// GetAlmAzure for unmarshalling response body from alm list definitions. With only azure populated
+type GetAlmAzure struct {
+	Azure []struct {
+		Key string `json:"key"`
+		URL string `json:"url"`
+	} `json:"azure"`
+}
+
+// Returns the resource represented by this file.
+func resourceSonarqubeAlmAzure() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeAlmAzureCreate,
+		Read:   resourceSonarqubeAlmAzureRead,
+		Update: resourceSonarqubeAlmAzureUpdate,
+		Delete: resourceSonarqubeAlmAzureDelete,
+
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"personalAccessToken": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceSonarqubeAlmAzureCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/create_azure"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"key":                 []string{d.Get("key").(string)},
+		"personalAccessToken": []string{d.Get("personal_access_token").(string)},
+		"url":                 []string{d.Get("url").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeAlmAzureCreate",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	d.SetId(d.Get("key").(string))
+
+	return resourceSonarqubeAlmAzureRead(d, m)
+}
+
+func resourceSonarqubeAlmAzureRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/list_definitions"
+	sonarQubeURL.RawQuery = url.Values{}.Encode() // Dunno if you can keep it empty tbh?
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeAlmAzureRead",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	AlmAzureReadResponse := GetAlmAzure{}
+	err = json.NewDecoder(resp.Body).Decode(&AlmAzureReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeAlmAzureRead: Failed to decode json into struct: %+v", err)
+	}
+	// Loop over all Azure instances to see if the Alm instance exists.
+	for _, value := range AlmAzureReadResponse.Azure {
+		if d.Id() == value.Key {
+			d.Set("key", value.Key)
+			d.Set("url", value.URL)
+			return nil
+		}
+	}
+	return fmt.Errorf("resourceSonarqubeAzureBindingRead: Failed to find azure binding: %+v", d.Id())
+
+}
+func resourceSonarqubeAlmAzureUpdate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/update_azure"
+	sonarQubeURL.RawQuery = url.Values{
+		"key":                 []string{d.Id()},
+		"personalAccessToken": []string{d.Get("personal_access_token").(string)},
+		"url":                 []string{d.Get("url").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeAlmAzureUpdate",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return resourceSonarqubeAlmAzureRead(d, m)
+}
+
+func resourceSonarqubeAlmAzureDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/delete"
+	sonarQubeURL.RawQuery = url.Values{
+		"key": []string{d.Get("key").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeAlmAzureDelete",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/sonarqube/resource_sonarqube_alm_azure_test.go
+++ b/sonarqube/resource_sonarqube_alm_azure_test.go
@@ -1,0 +1,56 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("sonarqube_alm_azure", &resource.Sweeper{
+		Name: "sonarqube_alm_azure",
+		F:    testSweepSonarqubeAlmAzure,
+	})
+}
+
+// TODO: implement sweeper to clean up projects: https://www.terraform.io/docs/extend/testing/acceptance-tests/sweepers.html
+func testSweepSonarqubeAlmAzure(r string) error {
+	return nil
+}
+
+func testAccSonarqubeAlmAzureName(rnd string, name string, url string) string {
+	return fmt.Sprintf(`
+		
+		resource "sonarqube_alm_azure" "%[1]s" {
+			key    = "%[2]s"
+			personal_access_token    = "my_pat"
+			url    = "%[3]s"
+		}`, rnd, name, url)
+}
+
+func TestAccSonarqubeAlmAzureName(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_alm_azure." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeAlmAzureName(rnd, "testAccSonarqubeAlmAzureName", "https://dev.azure.com/my-org"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubeAlmAzureName"),
+					resource.TestCheckResourceAttr(name, "url", "https://dev.azure.com/my-org"),
+				),
+			},
+			{
+				Config: testAccSonarqubeAlmAzureName(rnd, "testAccSonarqubeAlmAzureNameUpdate", "https://dev.azure.com/my-other-org"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "key", "testAccSonarqubeAlmAzureNameUpdate"),
+					resource.TestCheckResourceAttr(name, "url", "https://dev.azure.com/my-other-org"),
+				),
+			},
+		},
+	})
+}

--- a/sonarqube/resource_sonarqube_azure_binding.go
+++ b/sonarqube/resource_sonarqube_azure_binding.go
@@ -1,0 +1,171 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Returns the resource represented by this file.
+func resourceSonarqubeAzureBinding() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeAzureBindingCreate,
+		Read:   resourceSonarqubeAzureBindingRead,
+		Delete: resourceSonarqubeAzureBindingDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubeAzureBindingImport,
+		},
+		// Define the fields of this schema.
+		Schema: map[string]*schema.Schema{
+			"alm_setting": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"monorepo": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "false",
+				ForceNew: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"summary_comment_enabled": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "true",
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func checkAzureBindingSupport(conf *ProviderConfiguration) error {
+	if strings.ToLower(conf.sonarQubeEdition) == "community" {
+		return fmt.Errorf("Azure Devops Bindings are not supported in the Community edition of SonarQube. You are using: SonarQube %s version %s", conf.sonarQubeEdition, conf.sonarQubeVersion)
+	}
+	return nil
+}
+
+func resourceSonarqubeAzureBindingCreate(d *schema.ResourceData, m interface{}) error {
+	if err := checkAzureBindingSupport(m.(*ProviderConfiguration)); err != nil {
+		return err
+	}
+
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/set_azure_binding"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"almSetting":            []string{d.Get("alm_setting").(string)},
+		"monorepo":              []string{d.Get("monorepo").(string)},
+		"project":               []string{d.Get("project").(string)},
+		"repository":            []string{d.Get("repository").(string)},
+		"summaryCommentEnabled": []string{d.Get("summary_comment_enabled").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeAzureBindingCreate",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	id := fmt.Sprintf("%v/%v", d.Get("project").(string), d.Get("repository").(string))
+	d.SetId(id)
+
+	return resourceSonarqubeAzureBindingRead(d, m)
+}
+
+func resourceSonarqubeAzureBindingRead(d *schema.ResourceData, m interface{}) error {
+	if err := checkAzureBindingSupport(m.(*ProviderConfiguration)); err != nil {
+		return err
+	}
+
+	idSlice := strings.SplitN(d.Id(), "/", 2)
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/get_binding"
+	sonarQubeURL.RawQuery = url.Values{
+		"project": []string{idSlice[0]},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeAzureBindingRead",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Decode response into struct
+	BindingReadResponse := GetBinding{}
+	err = json.NewDecoder(resp.Body).Decode(&BindingReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeAzureBindingRead: Failed to decode json into struct: %+v", err)
+	}
+	// Loop over all branches to see if the main branch we need exists.
+	if idSlice[1] == BindingReadResponse.Repository && BindingReadResponse.Alm == "azure" {
+		d.Set("project", idSlice[0])
+		d.Set("repository", idSlice[1])
+		d.Set("alm_setting", BindingReadResponse.Key)
+		d.Set("monorepo", strconv.FormatBool(BindingReadResponse.Monorepo))
+		d.Set("summary_comment_enabled", strconv.FormatBool(BindingReadResponse.SummaryCommentEnabled))
+
+		return nil
+	}
+	return fmt.Errorf("resourceSonarqubeAzureBindingRead: Failed to find azure binding: %+v", d.Id())
+}
+
+func resourceSonarqubeAzureBindingDelete(d *schema.ResourceData, m interface{}) error {
+	if err := checkAzureBindingSupport(m.(*ProviderConfiguration)); err != nil {
+		return err
+	}
+
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/alm_settings/delete_binding"
+	sonarQubeURL.RawQuery = url.Values{
+		"project": []string{d.Get("project").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeAzureBindingDelete",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeAzureBindingImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceSonarqubeAzureBindingRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/sonarqube/resource_sonarqube_azure_binding.go
+++ b/sonarqube/resource_sonarqube_azure_binding.go
@@ -16,7 +16,7 @@ type GetAzureBinding struct {
 	Key        string `json:"key"`
 	Alm        string `json:"alm"`
 	Repository string `json:"repository"` // Azure DevOps Repository
-	Slug       string `json:"slug"`       // Azure DevOps Project (recorded as a slug by SonarQube??)
+	Slug       string `json:"slug"`       // Azure DevOps Project
 	URL        string `json:"url"`
 	Monorepo   bool   `json:"monorepo"`
 }

--- a/sonarqube/resource_sonarqube_azure_binding_test.go
+++ b/sonarqube/resource_sonarqube_azure_binding_test.go
@@ -1,0 +1,114 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("sonarqube_azure_binding", &resource.Sweeper{
+		Name: "sonarqube_azure_binding",
+		F:    testSweepSonarqubeAzureBinding,
+	})
+}
+
+// TODO: implement sweeper to clean up projects: https://www.terraform.io/docs/extend/testing/acceptance-tests/sweepers.html
+func testSweepSonarqubeAzureBinding(r string) error {
+	return nil
+}
+func testAccPreCheckAzureBindingSupport(t *testing.T) {
+	if err := checkAzureBindingSupport(testAccProvider.Meta().(*ProviderConfiguration)); err != nil {
+		t.Skipf("Skipping test of unsupported feature (Azure Binding)")
+	}
+}
+
+func testAccSonarqubeAzureBindingName(rnd string, projName string, almSetting string, repoName string) string {
+	return fmt.Sprintf(`
+		
+		resource "sonarqube_alm_azure" "%[1]s" {
+			key    = "%[3]s"
+			personal_access_token    = "my_pat"
+			url    = "https://dev.azure.com/my-org"
+		}
+
+		resource "sonarqube_project" "%[1]s" {
+			name       = "%[2]s"
+			project    = "%[2]s"
+			visibility = "public"
+		}
+		resource "sonarqube_azure_binding" "%[1]s" {
+			alm_setting   = sonarqube_alm_azure.%[1]s.key
+			monorepo     = "false"
+			project = sonarqube_project.%[1]s.project
+			repository   = "%[4]s"
+		}`, rnd, projName, almSetting, repoName)
+}
+
+func TestAccSonarqubeAzureBindingName(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_azure_binding." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAzureBindingSupport(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeAzureBindingName(rnd, "testAccSonarqubeAzureBindingName", "azure", "testAccSonarqubeAzureBindingName"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
+					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
+				),
+			},
+			{
+				Config: testAccSonarqubeAzureBindingName(rnd, "testAccSonarqubeAzureBindingName", "azurea", "testAccSonarqubeAzureBindingName"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azurea"),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azurea"),
+				),
+			},
+			{
+				Config: testAccSonarqubeAzureBindingName(rnd, "testAccSonarqubeAzureBindingName", "azure", "org/testAccSonarqubeAzureBindingName"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "org/testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
+				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "repository", "org/testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
+				),
+			},
+		},
+	})
+}

--- a/sonarqube/resource_sonarqube_azure_binding_test.go
+++ b/sonarqube/resource_sonarqube_azure_binding_test.go
@@ -24,7 +24,7 @@ func testAccPreCheckAzureBindingSupport(t *testing.T) {
 	}
 }
 
-func testAccSonarqubeAzureBindingName(rnd string, projName string, almSetting string, repoName string) string {
+func testAccSonarqubeAzureBindingName(rnd string, projKey string, almSetting string, projName string, repoName string) string {
 	return fmt.Sprintf(`
 		
 		resource "sonarqube_alm_azure" "%[1]s" {
@@ -40,10 +40,10 @@ func testAccSonarqubeAzureBindingName(rnd string, projName string, almSetting st
 		}
 		resource "sonarqube_azure_binding" "%[1]s" {
 			alm_setting   = sonarqube_alm_azure.%[1]s.key
-			monorepo     = "false"
 			project = sonarqube_project.%[1]s.project
-			repository   = "%[4]s"
-		}`, rnd, projName, almSetting, repoName)
+			project_name   = "%[4]s"
+			repository_name   = "%[5]s"
+		}`, rnd, projKey, almSetting, projName, repoName)
 }
 
 func TestAccSonarqubeAzureBindingName(t *testing.T) {
@@ -55,12 +55,12 @@ func TestAccSonarqubeAzureBindingName(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSonarqubeAzureBindingName(rnd, "testAccSonarqubeAzureBindingName", "azure", "testAccSonarqubeAzureBindingName"),
+				Config: testAccSonarqubeAzureBindingName(rnd, "testSqProjectKey", "azure", "testAzProjName", "testAzRepoName"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "project", "testSqProjectKey"),
 					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
-					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "project_name", "testAzProjName"),
+					resource.TestCheckResourceAttr(name, "repository_name", "testAzRepoName"),
 				),
 			},
 			{
@@ -68,17 +68,19 @@ func TestAccSonarqubeAzureBindingName(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "project", "testSqProjectKey"),
 					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
+					resource.TestCheckResourceAttr(name, "project_name", "testAzProjName"),
+					resource.TestCheckResourceAttr(name, "repository_name", "testAzRepoName"),
 				),
 			},
 			{
-				Config: testAccSonarqubeAzureBindingName(rnd, "testAccSonarqubeAzureBindingName", "azurea", "testAccSonarqubeAzureBindingName"),
+				Config: testAccSonarqubeAzureBindingName(rnd, "testSqProjectKey", "azurea", "testAzProjName", "testAzRepoName"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "project", "testSqProjectKey"),
 					resource.TestCheckResourceAttr(name, "alm_setting", "azurea"),
+					resource.TestCheckResourceAttr(name, "project_name", "testAzProjName"),
+					resource.TestCheckResourceAttr(name, "repository_name", "testAzRepoName"),
 				),
 			},
 			{
@@ -86,17 +88,19 @@ func TestAccSonarqubeAzureBindingName(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "repository", "testAccSonarqubeAzureBindingName"),
+					resource.TestCheckResourceAttr(name, "project", "testSqProjectKey"),
 					resource.TestCheckResourceAttr(name, "alm_setting", "azurea"),
+					resource.TestCheckResourceAttr(name, "project_name", "testAzProjName"),
+					resource.TestCheckResourceAttr(name, "repository_name", "testAzRepoName"),
 				),
 			},
 			{
-				Config: testAccSonarqubeAzureBindingName(rnd, "testAccSonarqubeAzureBindingName", "azure", "org/testAccSonarqubeAzureBindingName"),
+				Config: testAccSonarqubeAzureBindingName(rnd, "testSqProjectKey", "azurea", "testAzProjName", "testAzRepoName"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "repository", "org/testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
+					resource.TestCheckResourceAttr(name, "project", "testSqProjectKey"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azurea"),
+					resource.TestCheckResourceAttr(name, "project_name", "testAzProjName"),
+					resource.TestCheckResourceAttr(name, "repository_name", "testAzRepoName"),
 				),
 			},
 			{
@@ -104,9 +108,10 @@ func TestAccSonarqubeAzureBindingName(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(name, "project", "testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "repository", "org/testAccSonarqubeAzureBindingName"),
-					resource.TestCheckResourceAttr(name, "alm_setting", "azure"),
+					resource.TestCheckResourceAttr(name, "project", "testSqProjectKey"),
+					resource.TestCheckResourceAttr(name, "alm_setting", "azurea"),
+					resource.TestCheckResourceAttr(name, "project_name", "testAzProjName"),
+					resource.TestCheckResourceAttr(name, "repository_name", "testAzRepoName"),
 				),
 			},
 		},

--- a/sonarqube/resource_sonarqube_azure_binding_test.go
+++ b/sonarqube/resource_sonarqube_azure_binding_test.go
@@ -28,9 +28,9 @@ func testAccSonarqubeAzureBindingName(rnd string, projKey string, almSetting str
 	return fmt.Sprintf(`
 		
 		resource "sonarqube_alm_azure" "%[1]s" {
-			key    = "%[3]s"
-			personal_access_token    = "my_pat"
-			url    = "https://dev.azure.com/my-org"
+			key                   = "%[3]s"
+			personal_access_token = "my_pat"
+			url                   = "https://dev.azure.com/my-org"
 		}
 
 		resource "sonarqube_project" "%[1]s" {
@@ -39,10 +39,11 @@ func testAccSonarqubeAzureBindingName(rnd string, projKey string, almSetting str
 			visibility = "public"
 		}
 		resource "sonarqube_azure_binding" "%[1]s" {
-			alm_setting   = sonarqube_alm_azure.%[1]s.key
-			project = sonarqube_project.%[1]s.project
-			project_name   = "%[4]s"
-			repository_name   = "%[5]s"
+			alm_setting     = sonarqube_alm_azure.%[1]s.key
+			project         = sonarqube_project.%[1]s.project
+			project_name    = "%[4]s"
+			repository_name = "%[5]s"
+			monorepo        = false
 		}`, rnd, projKey, almSetting, projName, repoName)
 }
 


### PR DESCRIPTION
Based off of the existing github alm and binding.
Tested against a Developer edition instance of SonarQube integrating with a free Azure DevOps account I setup.