### PR TITLE
Added field project for sonarqube_webhook resource

### DIFF
--- a/sonarqube/resource_sonarqube_webhook.go
+++ b/sonarqube/resource_sonarqube_webhook.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Webhook struct {
-	Key    string `json:"key"`
-	Name   string `json:"name"`
-	Url    string `json:"url"`
-	Secret string `json:"secret"`
+	Key     string `json:"key"`
+	Name    string `json:"name"`
+	Url     string `json:"url"`
+	Secret  string `json:"secret"`
+	Project string `json:"project"` // field project added since 7.1
 }
 
 type CreateWebhookResponse struct {
@@ -52,6 +53,11 @@ func resourceSonarqubeWebhook() *schema.Resource {
 				Optional:  true,
 				Computed:  true,
 			},
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The key of the project that will own the webhook (optional).",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -66,6 +72,9 @@ func resourceSonarqubeWebhookCreate(d *schema.ResourceData, m interface{}) error
 	}
 	if secret, ok := d.GetOk("secret"); ok {
 		params.Set("secret", secret.(string))
+	}
+	if project, ok := d.GetOk("project"); ok {
+		params.Set("project", project.(string))
 	}
 	sonarQubeURL.RawQuery = params.Encode()
 
@@ -125,6 +134,9 @@ func resourceSonarqubeWebhookRead(d *schema.ResourceData, m interface{}) error {
 			if secret, ok := d.GetOk("secret"); ok {
 				d.Set("secret", secret.(string))
 			}
+			if project, ok := d.GetOk("project"); ok {
+				d.Set("project", project.(string))
+			}
 			return nil
 		}
 	}
@@ -143,6 +155,9 @@ func resourceSonarqubeWebhookUpdate(d *schema.ResourceData, m interface{}) error
 	}
 	if secret, ok := d.GetOk("secret"); ok {
 		params.Set("secret", secret.(string))
+	}
+	if project, ok := d.GetOk("project"); ok {
+		params.Set("project", project.(string))
 	}
 	sonarQubeURL.RawQuery = params.Encode()
 

--- a/sonarqube/resource_sonarqube_webhook_test.go
+++ b/sonarqube/resource_sonarqube_webhook_test.go
@@ -88,3 +88,55 @@ resource "sonarqube_webhook" "%s" {
 }
 `, rnd, name, url, secret)
 }
+
+func TestAccSonarqubeWebhookProjectBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	resourceName := "sonarqube_webhook." + rnd
+	project := "sonarqube_webhook." + rnd
+
+	name := acctest.RandString(10)
+	url := fmt.Sprintf("https://%s.com", acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	secret := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeWebhookProjectBasicConfig(rnd, name, url, secret, project),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "url", url),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "url", url),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeWebhookProjectBasicConfig(rnd, name, url, secret string, project string) string {
+	return fmt.Sprintf(`
+resource "sonarqube_project" "%[1]s" {
+	name       = "%[5]s"
+	project    = "%[5]s"
+	visibility = "public" 
+}
+
+resource "sonarqube_webhook" "%[1]s" {
+	name    = "%[2]s"
+	url     = "%[3]s"
+	secret  = "%[4]s"
+	project = sonarqube_project.%[1]s.name
+}
+`, rnd, name, url, secret, project)
+}


### PR DESCRIPTION
# Updated resource
 - `sonarqube_webhook`

# Changes/fixes
Added **optional** parameter `project`for the resources, as documented in the [API page](https://next.sonarqube.com/sonarqube/web_api/api/webhooks/create).
This parameter was intruduced in v7.1 and reflects Tthe key of the project that will own the webhook.







