### PR TITLE
sonarqube_qualitygates are imported by their names

### DIFF
--- a/docs/resources/sonarqube_qualitygate.md
+++ b/docs/resources/sonarqube_qualitygate.md
@@ -76,8 +76,8 @@ The following attributes are exported:
 
 ## Import
 
-Quality Gates can be imported using their numeric value
+Quality Gates can be imported using its name
 
 ```terraform
-terraform import sonarqube_qualitygate.main 11
+terraform import sonarqube_qualitygate.main my-cool-gate
 ```


### PR DESCRIPTION
Importing qualitygates are done via their name, not number. I'm guessing this was some relic from the past