### PR TITLE
fix: alm settings update gitlab returns no content

### DIFF
--- a/sonarqube/resource_sonarqube_alm_gitlab.go
+++ b/sonarqube/resource_sonarqube_alm_gitlab.go
@@ -127,7 +127,7 @@ func resourceSonarqubeAlmGitlabUpdate(d *schema.ResourceData, m interface{}) err
 		m.(*ProviderConfiguration).httpClient,
 		"POST",
 		sonarQubeURL.String(),
-		http.StatusOK,
+		http.StatusNoContent,
 		"resourceSonarqubeAlmGitlabUpdate",
 	)
 	if err != nil {


### PR DESCRIPTION
Should fix the error "failed to decode error response json into struct: EOF" when updating resource sonarqube_alm_gitlab