### PR TITLE
Fix `sonarqube_permission_template` resource when `default` is `true`

### DIFF
--- a/sonarqube/resource_sonarqube_permissions_template.go
+++ b/sonarqube/resource_sonarqube_permissions_template.go
@@ -100,6 +100,7 @@ func resourceSonarqubePermissionTemplateCreate(d *schema.ResourceData, m interfa
 
 	// If default is set to true, set this permission template as the default.
 	if d.Get("default").(bool) {
+		sonarQubeURL = m.(*ProviderConfiguration).sonarQubeURL
 		err = resourceSonarqubePermissionTemplateSetDefault(sonarQubeURL, d.Id(), m)
 		if err != nil {
 			return err
@@ -189,6 +190,7 @@ func resourceSonarqubePermissionTemplateUpdate(d *schema.ResourceData, m interfa
 
 	// If default is set to true, set this permission template as the default.
 	if d.Get("default").(bool) {
+		sonarQubeURL = m.(*ProviderConfiguration).sonarQubeURL
 		err = resourceSonarqubePermissionTemplateSetDefault(sonarQubeURL, d.Id(), m)
 		if err != nil {
 			return err


### PR DESCRIPTION
When `default` is enabled on a `sonarqube_permission_template` resource it is producing the wrong URL to the API. This is because the modified URL is being used on the call to the `resourceSonarqubePermissionTemplateSetDefault` method.

Example error:

```
Error: error setting Sonarqube permission template to default: API returned an error: Unknown url : /api/permissions/create_template/api/permissions/set_default_template
│ 
│   with module.sonarqube_configuration.module.permissions.sonarqube_permission_template.default,
│   on modules/sonarqube/configuration/permissions/main.tf line 26, in resource "sonarqube_permission_template" "default":
│   26: resource "sonarqube_permission_template" "default" {
```