### PR TITLE
allow portofolio to be created in Data Center Edition

### DIFF
--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -54,11 +54,11 @@ func resourceSonarqubePortfolio() *schema.Resource {
 			State: resourceSonarqubePortfolioImport,
 		},
 		// Validation that runs after the read in plan has completed (https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/customizing-differences)
-        CustomizeDiff: customdiff.All(
+		CustomizeDiff: customdiff.All(
 			func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
 				return validatePortfolioResource(d)
 			},
-       ),
+		),
 
 		// Define the fields of this schema.
 		Schema: map[string]*schema.Schema{
@@ -94,7 +94,6 @@ func resourceSonarqubePortfolio() *schema.Resource {
 				Default:      NONE,
 				ForceNew:     false,
 				ValidateFunc: validation.StringInSlice([]string{NONE, MANUAL, TAGS, REGEXP, REST}, false),
-				
 			},
 			"branch": { // Only active for TAGS, REGEXP and REST
 				Type:        schema.TypeString,
@@ -147,8 +146,8 @@ func resourceSonarqubePortfolio() *schema.Resource {
 }
 
 func checkPortfolioSupport(conf *ProviderConfiguration) error {
-	if strings.ToLower(conf.sonarQubeEdition) != "enterprise" {
-		return fmt.Errorf("portfolios are only supported in the Enterprise edition of SonarQube. You are using: SonarQube %s version %s", conf.sonarQubeEdition, conf.sonarQubeVersion)
+	if strings.ToLower(conf.sonarQubeEdition) == "community" {
+		return fmt.Errorf("portfolios are only supported in the Enterprise and Data Center editions of SonarQube. You are using: SonarQube %s version %s", conf.sonarQubeEdition, conf.sonarQubeVersion)
 	}
 	return nil
 }

--- a/sonarqube/resource_sonarqube_portfolio.go
+++ b/sonarqube/resource_sonarqube_portfolio.go
@@ -146,8 +146,9 @@ func resourceSonarqubePortfolio() *schema.Resource {
 }
 
 func checkPortfolioSupport(conf *ProviderConfiguration) error {
-	if strings.ToLower(conf.sonarQubeEdition) == "community" {
-		return fmt.Errorf("portfolios are only supported in the Enterprise and Data Center editions of SonarQube. You are using: SonarQube %s version %s", conf.sonarQubeEdition, conf.sonarQubeVersion)
+	edition := strings.ToLower(conf.sonarQubeEdition)
+	if edition != "enterprise" && edition != "data center" {
+		return fmt.Errorf("portfolios are only supported in the Enterprise and Datacenter editions of SonarQube. You are using: SonarQube %s version %s", conf.sonarQubeEdition, conf.sonarQubeVersion)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixed the issue that you could not create portfolio if version of SonarQube is Data Center

<img width="986" alt="image" src="https://github.com/jdamata/terraform-provider-sonarqube/assets/3426701/a68a97a4-f124-47c3-af61-9896faa7dd5b">

SONAR_VERSION =  "10.3.0.82913"
SONAR_EDITION =  "Data Center"

<img width="947" alt="image" src="https://github.com/jdamata/terraform-provider-sonarqube/assets/3426701/a7f0ce80-31c1-4aba-98bd-9e89496b5c6f">