### PR TITLE
fix: allow login_name on global analysis token

### DIFF
--- a/sonarqube/resource_sonarqube_user_token.go
+++ b/sonarqube/resource_sonarqube_user_token.go
@@ -101,7 +101,7 @@ func resourceSonarqubeUserTokenCreate(d *schema.ResourceData, m interface{}) err
 		"type": []string{string(tokenType)},
 	}
 
-	if tokenType == UserToken {
+	if (tokenType == UserToken) || (tokenType == GlobalAnalysisToken) {
 		loginName := d.Get("login_name").(string)
 		if loginName != "" {
 			rawQuery.Add("login", loginName)


### PR DESCRIPTION
The API permits supplying a `login_name` for a GlobalAnalysisToken type too.

fixes: #223