### PR TITLE
added sonarqube_qualityprofile_deactivate_rule function

### DIFF
--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -98,6 +98,7 @@ func Provider() *schema.Provider {
 			"sonarqube_rule":                               resourceSonarqubeRule(),
 			"sonarqube_setting":                            resourceSonarqubeSettings(),
 			"sonarqube_qualityprofile_activate_rule":       resourceSonarqubeQualityProfileRule(),
+			"sonarqube_qualityprofile_deactivate_rule":     resourceSonarqubeQualityProfileRuleDeactivate(),
 			"sonarqube_alm_github":                         resourceSonarqubeAlmGithub(),
 			"sonarqube_github_binding":                     resourceSonarqubeGithubBinding(),
 			"sonarqube_alm_gitlab":                         resourceSonarqubeAlmGitlab(),

--- a/sonarqube/resource_sonarqube_qualityprofile_deactivate_rule.go
+++ b/sonarqube/resource_sonarqube_qualityprofile_deactivate_rule.go
@@ -1,0 +1,138 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type Inactives struct {
+	QProfile string   `json:"qProfile"`
+	Inherit  string   `json:"inherit"`
+	Severity string   `json:"severity"`
+	Params   []Params `json:"params"`
+}
+
+type GetInactiveRules struct {
+	Rule      Rule        `json:"rule"`
+	Inactives []Inactives `json:"inactives"`
+}
+
+func resourceSonarqubeQualityProfileRuleDeactivate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSonarqubeQualityProfileRuleDeactivateCreate,
+		Delete: resourceSonarqubeQualityProfileRuleDeactivateDelete,
+		Read:   resourceSonarqubeQualityProfileRuleDeactivateRead,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubeQualityProfileRuleDeactivateImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Quality Profile key. Can be obtained through api/qualityprofiles/search",
+			},
+			"rule": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Rule key",
+			},
+		},
+	}
+}
+
+func resourceSonarqubeQualityProfileRuleDeactivateCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualityprofiles/deactivate_rule"
+	sonarQubeURL.RawQuery = url.Values{
+		"key":  []string{d.Get("key").(string)},
+		"rule": []string{d.Get("rule").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeQualityProfileRuleDeactivateCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeQualityProfileRuleDeactivateCreate: Failed to deactivate rule: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	d.SetId(d.Get("rule").(string))
+	return resourceSonarqubeQualityProfileRuleDeactivateRead(d, m)
+}
+
+func resourceSonarqubeQualityProfileRuleDeactivateDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/qualityprofiles/activate_rule"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"key":  []string{d.Get("key").(string)},
+		"rule": []string{d.Get("rule").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeQualityProfileRuleDeactivateDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeQualityProfileRuleDeactivateDelete: Failed to activate rule: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeQualityProfileRuleDeactivateRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/rules/show"
+	sonarQubeURL.RawQuery = url.Values{
+		"key":     []string{d.Id()},
+		"actives": []string{"false"},
+	}.Encode()
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeQualityProfileRuleDeactivateRead",
+	)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	inactiveRuleReadResponse := GetInactiveRules{}
+	err = json.NewDecoder(resp.Body).Decode(&inactiveRuleReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeQualityProfileRuleDeactivateRead: Failed to decode json into struct: %+v", err)
+	}
+
+	if d.Id() == inactiveRuleReadResponse.Rule.RuleKey {
+		d.SetId(inactiveRuleReadResponse.Rule.RuleKey)
+		return nil
+	}
+
+	return fmt.Errorf("resourceSonarqubeQualityProfileRuleDeactivateRead: Failed to find project: %+v", d.Id())
+}
+
+func resourceSonarqubeQualityProfileRuleDeactivateImporter(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if err := resourceSonarqubeQualityProfileRuleDeactivateRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/sonarqube/resource_sonarqube_qualityprofile_deactivate_rule_test.go
+++ b/sonarqube/resource_sonarqube_qualityprofile_deactivate_rule_test.go
@@ -1,0 +1,65 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("sonarqube_qualityprofile_deactivate_rule", &resource.Sweeper{
+		Name: "sonarqube_qualityprofile_deactivate_rule",
+		F:    testSweeepSonarqibeQualityprofileDeactivateRuleSweeper,
+	})
+}
+
+func testSweeepSonarqibeQualityprofileDeactivateRuleSweeper(r string) error {
+	return nil
+}
+
+func testAccSonarqubeQualityprofileDeactivateRuleBasicConfig(rnd string, name string, key string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_qualityprofile" "%[1]s" {
+			name     = "%[2]s"
+			language = "xml"
+		}
+
+		data "sonarqube_rule" "%[1]s" {
+		  key = "squid:forbidSonar"
+		}
+
+		resource "sonarqube_qualityprofile_deactivate_rule" "%[1]s" {
+			key = sonarqube_qualityprofile.%[1]s.key
+			rule = data.sonarqube_rule.%[1]s.key
+		}`, rnd, name, key)
+}
+
+func TestAccSonarqubeQualityprofileDeactivateRuleBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_qualityprofile_deactivate_rule." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeQualityprofileDeactivateRuleBasicConfig(rnd, "testProfile", "xml:S3420"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(name, "key"),
+					resource.TestCheckResourceAttrSet(name, "rule"),
+				),
+			},
+			{
+				ResourceName:            name,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key", "rule"},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(name, "key"),
+					resource.TestCheckResourceAttrSet(name, "rule"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Added function to deactivate rule in a qualityprofile

```
resource "sonarqube_qualityprofile" "py_ckecks" {
    name     = "Inherited py checks for deactiovation tests"
    language = "py"
    is_default = false
    parent = "Sonar way"
}

data "sonarqube_rule" "itterator" {
  key = "python:S2876"
}
resource "sonarqube_qualityprofile_deactivate_rule" "inactive_rule" {
    key = sonarqube_qualityprofile.py_ckecks.key
    rule = data.sonarqube_rule.itterator.key 
}
```