### PR TITLE
fix: resource sonarqube user token read

### DIFF
--- a/sonarqube/resource_sonarqube_user_token.go
+++ b/sonarqube/resource_sonarqube_user_token.go
@@ -205,9 +205,7 @@ func resourceSonarqubeUserTokenRead(d *schema.ResourceData, m interface{}) error
 			if login_name[1] == value.Name {
 				d.SetId(fmt.Sprintf("%s/%s", getTokensResponse.Login, value.Name))
 				errs := []error{}
-				if d.Get("login_name").(string) != "" {
-					errs = append(errs, d.Set("login_name", getTokensResponse.Login))
-				}
+				errs = append(errs, d.Set("login_name", getTokensResponse.Login))
 				errs = append(errs, d.Set("name", value.Name))
 				if value.ExpirationDate != "" {
 					dateReceived, errTimeParse := time.Parse("2006-01-02T15:04:05-0700", value.ExpirationDate)

--- a/sonarqube/resource_sonarqube_user_token.go
+++ b/sonarqube/resource_sonarqube_user_token.go
@@ -205,7 +205,11 @@ func resourceSonarqubeUserTokenRead(d *schema.ResourceData, m interface{}) error
 			if login_name[1] == value.Name {
 				d.SetId(fmt.Sprintf("%s/%s", getTokensResponse.Login, value.Name))
 				errs := []error{}
-				errs = append(errs, d.Set("login_name", getTokensResponse.Login))
+				// Set login_name only if it's a token for another user (not the authenticated one),
+				// or if this is an import and only the ID is provided (i.e., name is not set).
+				if d.Get("login_name").(string) != "" || d.Get("name").(string) == "" {
+					errs = append(errs, d.Set("login_name", getTokensResponse.Login))
+				}
 				errs = append(errs, d.Set("name", value.Name))
 				if value.ExpirationDate != "" {
 					dateReceived, errTimeParse := time.Parse("2006-01-02T15:04:05-0700", value.ExpirationDate)


### PR DESCRIPTION
### Fix: Ensure login_name is set correctly during token import

This PR fixes an issue in the sonarqube_user_token resource where the login_name field was not being populated during import. The previous logic relied on login_name being already set, which is not the case during an import—only the id is present at that point. As a result, the field was left empty.

The fix updates the conditional check to ensure login_name is only set when appropriate—either when it's a token for another user or during import (when only the ID is available)—ensuring correct behavior across read and import operations.