### PR TITLE
fix: resource sonarqube quality profile deletion

### DIFF
--- a/sonarqube/resource_sonarqube_qualityprofile.go
+++ b/sonarqube/resource_sonarqube_qualityprofile.go
@@ -198,9 +198,11 @@ func resourceSonarqubeQualityProfileDelete(d *schema.ResourceData, m interface{}
 		"language":       []string{d.Get("language").(string)},
 	}.Encode()
 
-	err := setDefaultQualityProfile(d, m, false)
-	if err != nil {
-		return err
+	if d.Get("is_default").(bool) {
+		err := setDefaultQualityProfile(d, m, false)
+		if err != nil {
+			return err
+		}
 	}
 
 	resp, err := httpRequestHelper(


### PR DESCRIPTION
### Fix: Prevent unintended change to default quality profile on deletion

This PR addresses an issue in the sonarqube_qualityprofile resource where the deletion logic would always attempt to change the default quality profile for a language, regardless of whether the profile being deleted was actually the current default.

The fix adds a check to ensure that the default profile is only reset if the profile being deleted is marked as default (is_default = true). This prevents unnecessary or incorrect updates to the default quality profile configuration during deletion.
