### PR TITLE
fix: Set user token type to state on read

### DIFF
--- a/sonarqube/resource_sonarqube_user_token.go
+++ b/sonarqube/resource_sonarqube_user_token.go
@@ -210,6 +210,9 @@ func resourceSonarqubeUserTokenRead(d *schema.ResourceData, m interface{}) error
 				if d.Get("login_name").(string) != "" || d.Get("name").(string) == "" {
 					errs = append(errs, d.Set("login_name", getTokensResponse.Login))
 				}
+				if d.Get("type").(string) != value.Type {
+					errs = append(errs, d.Set("type", value.Type))
+				}
 				errs = append(errs, d.Set("name", value.Name))
 				if value.ExpirationDate != "" {
 					dateReceived, errTimeParse := time.Parse("2006-01-02T15:04:05-0700", value.ExpirationDate)

--- a/sonarqube/resource_sonarqube_user_token_test.go
+++ b/sonarqube/resource_sonarqube_user_token_test.go
@@ -44,6 +44,7 @@ func TestAccSonarqubeUserTokenBasic(t *testing.T) {
 				Config: testAccSonarqubeUserTokenBasicConfig(rnd, "testAccSonarqubeUserToken"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserToken"),
+					resource.TestCheckResourceAttr(name, "type", string(UserToken)),
 				),
 			},
 		},
@@ -78,6 +79,7 @@ func TestAccSonarqubeUserTokenWithExpirationDate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenWithExpirationDate"),
 					resource.TestCheckResourceAttr(name, "expiration_date", expiration_date),
+					resource.TestCheckResourceAttr(name, "type", string(UserToken)),
 				),
 			},
 		},
@@ -108,6 +110,7 @@ func TestAccSonarqubeUserTokenNoLogin(t *testing.T) {
 				Config: testAccSonarqubeUserTokenNoLoginConfig(rnd, "testAccSonarqubeUserTokenNoLogin"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenNoLogin"),
+					resource.TestCheckResourceAttr(name, "type", string(UserToken)),
 				),
 			},
 		},
@@ -139,7 +142,7 @@ func TestAccSonarqubeUserTokenGlobalAnalysisToken(t *testing.T) {
 				Config: testAccSonarqubeUserTokenGlobalAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenGlobalAnalysisToken"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenGlobalAnalysisToken"),
-					resource.TestCheckResourceAttr(name, "type", "GLOBAL_ANALYSIS_TOKEN"),
+					resource.TestCheckResourceAttr(name, "type", string(GlobalAnalysisToken)),
 				),
 			},
 		},
@@ -177,7 +180,7 @@ func TestAccSonarqubeUserTokenProjectAnalysisToken(t *testing.T) {
 				Config: testAccSonarqubeUserTokenProjectAnalysisTokenConfig(rnd, "testAccSonarqubeUserTokenProjectAnalysisToken"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(name, "name", "testAccSonarqubeUserTokenProjectAnalysisToken"),
-					resource.TestCheckResourceAttr(name, "type", "PROJECT_ANALYSIS_TOKEN"),
+					resource.TestCheckResourceAttr(name, "type", string(ProjectAnalysisToken)),
 				),
 			},
 		},


### PR DESCRIPTION
# Fix: Ensure token's type is set correctly during token read/import

This PR fixes an issue in the sonarqube_user_token resource where the type field was not being populated during import/read. 

After importing an existing user token, this cause me issues because it asked for deletion then creation of a token, since the property is forcing replacement when changed.