### PR TITLE
Add update functionality for Sonarqube project main branch resource

### DIFF
--- a/sonarqube/resource_sonarqube_project_main_branch.go
+++ b/sonarqube/resource_sonarqube_project_main_branch.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -57,10 +58,10 @@ func resourceSonarqubeProjectMainBranch() *schema.Resource {
 
 func resourceSonarqubeProjectMainBranchCreate(d *schema.ResourceData, m interface{}) error {
 	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
-	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_branches/set_main"
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_branches/rename"
 
 	sonarQubeURL.RawQuery = url.Values{
-		"branch":  []string{d.Get("name").(string)},
+		"name":    []string{d.Get("name").(string)},
 		"project": []string{d.Get("project").(string)},
 	}.Encode()
 
@@ -119,17 +120,105 @@ func resourceSonarqubeProjectMainBranchRead(d *schema.ResourceData, m interface{
 	return fmt.Errorf("resourceSonarqubeProjectMainBranchRead: Failed to find project main branch: %+v", d.Id())
 }
 
-func resourceSonarqubeProjectMainBranchUpdate(d *schema.ResourceData, m interface{}) error {
-	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
-	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_branches/set_main"
-
+// getBranches retrieves all branches for a given project
+func getBranches(conf *ProviderConfiguration, projectKey string) (*GetBranches, error) {
+	sonarQubeURL := conf.sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_branches/list"
 	sonarQubeURL.RawQuery = url.Values{
-		"branch":  []string{d.Get("name").(string)},
-		"project": []string{d.Get("project").(string)},
+		"project": []string{projectKey},
 	}.Encode()
 
 	resp, err := httpRequestHelper(
-		m.(*ProviderConfiguration).httpClient,
+		conf.httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"getBranches",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	branchResponse := &GetBranches{}
+	err = json.NewDecoder(resp.Body).Decode(branchResponse)
+	if err != nil {
+		return nil, fmt.Errorf("getBranches: Failed to decode json into struct: %+v", err)
+	}
+
+	return branchResponse, nil
+}
+
+// deleteBranch removes a non-main branch from a project
+func deleteBranch(conf *ProviderConfiguration, projectKey, branchName string) error {
+	sonarQubeURL := conf.sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_branches/delete"
+	sonarQubeURL.RawQuery = url.Values{
+		"branch":  []string{branchName},
+		"project": []string{projectKey},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		conf.httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"deleteBranch",
+	)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeProjectMainBranchUpdate(d *schema.ResourceData, m interface{}) error {
+	conf := m.(*ProviderConfiguration)
+	sonarQubeURL := conf.sonarQubeURL
+
+	projectKey := d.Get("project").(string)
+	targetBranchName := d.Get("name").(string)
+
+	// set_main endpoint was introduced in SonarQube 10.2
+	minimumVersionForSetMain, _ := version.NewVersion("10.2")
+	useSetMainEndpoint := conf.sonarQubeVersion.GreaterThanOrEqual(minimumVersionForSetMain)
+
+	var endpoint, paramName string
+	if useSetMainEndpoint {
+		endpoint = "/api/project_branches/set_main"
+		paramName = "branch"
+	} else {
+		// For older versions using rename, we need to check if the target branch already exists
+		// If it does and it's not the main branch, delete it first to avoid conflicts
+		branches, err := getBranches(conf, projectKey)
+		if err != nil {
+			return fmt.Errorf("resourceSonarqubeProjectMainBranchUpdate: Failed to get branches: %+v", err)
+		}
+
+		for _, branch := range branches.Branches {
+			if branch.Name == targetBranchName && !branch.IsMain {
+				// Delete the existing non-main branch before renaming
+				if err := deleteBranch(conf, projectKey, targetBranchName); err != nil {
+					return fmt.Errorf("resourceSonarqubeProjectMainBranchUpdate: Failed to delete existing branch: %+v", err)
+				}
+				break
+			}
+		}
+
+		endpoint = "/api/project_branches/rename"
+		paramName = "name"
+	}
+
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + endpoint
+
+	sonarQubeURL.RawQuery = url.Values{
+		paramName: []string{targetBranchName},
+		"project": []string{projectKey},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		conf.httpClient,
 		"POST",
 		sonarQubeURL.String(),
 		http.StatusNoContent,
@@ -140,7 +229,7 @@ func resourceSonarqubeProjectMainBranchUpdate(d *schema.ResourceData, m interfac
 	}
 	defer resp.Body.Close()
 
-	id := fmt.Sprintf("%v/%v", d.Get("project").(string), d.Get("name").(string))
+	id := fmt.Sprintf("%v/%v", projectKey, targetBranchName)
 	d.SetId(id)
 
 	return resourceSonarqubeProjectMainBranchRead(d, m)

--- a/sonarqube/resource_sonarqube_project_main_branch_test.go
+++ b/sonarqube/resource_sonarqube_project_main_branch_test.go
@@ -92,3 +92,64 @@ func TestAccSonarqubeProjectMainBranchName(t *testing.T) {
 		},
 	})
 }
+
+func testAccSonarqubeProjectMainBranchConflictingBranch(rnd string, projName string, mainBranchName string, extraBranchName string) string {
+	return fmt.Sprintf(`
+		resource "sonarqube_project" "%[1]s" {
+			name       = "%[2]s"
+			project    = "%[2]s"
+			visibility = "public"
+		}
+
+		resource "sonarqube_project_main_branch" "%[1]s" {
+			name    = "%[3]s"
+			project = sonarqube_project.%[1]s.project
+		}
+
+		resource "sonarqube_project_branch" "%[1]s_extra" {
+			name    = "%[4]s"
+			project = sonarqube_project.%[1]s.project
+		}`, rnd, projName, mainBranchName, extraBranchName)
+}
+
+// TestAccSonarqubeProjectMainBranchConflictResolution tests that when updating
+// the main branch to a name that already exists as a non-main branch, the provider
+// correctly deletes the conflicting branch first (for SonarQube < 10.2 using rename API)
+func TestAccSonarqubeProjectMainBranchConflictResolution(t *testing.T) {
+	rnd := generateRandomResourceName()
+	name := "sonarqube_project_main_branch." + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create a project with main branch named "main" and an extra branch "develop"
+				Config: testAccSonarqubeProjectMainBranchConflictingBranch(rnd, "testAccConflictResolution", "main", "develop"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccConflictResolution"),
+					resource.TestCheckResourceAttr(name, "name", "main"),
+				),
+			},
+			{
+				// Step 2: Update main branch to "develop" - should delete the existing non-main "develop" branch
+				// and then rename "main" to "develop" (for SonarQube < 10.2) or set "develop" as main (>= 10.2)
+				Config: testAccSonarqubeProjectMainBranchName(rnd, "testAccConflictResolution", "develop"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccConflictResolution"),
+					resource.TestCheckResourceAttr(name, "name", "develop"),
+				),
+			},
+			{
+				// Step 3: Verify import still works after conflict resolution
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "project", "testAccConflictResolution"),
+					resource.TestCheckResourceAttr(name, "name", "develop"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Previously when trying to change the branch through my terraform configuration. It would show this as a destructive action and error during the apply if the branch already existed:

```
Error: API returned an error for resource resourceSonarqubeProjectMainBranchCreate: Impossible to update branch name: a branch with name "develop" already exists in the project.
```


SonarQube added support in the UI for changing the default branch. It uses a `/api/project_branches/set_main` endpoint:
<img width="1497" height="152" alt="image" src="https://github.com/user-attachments/assets/43be0231-b650-4360-9e22-f75b19687f81" />

This PR adds a Update function to facilitate this behavior.