### PR TITLE
feat: add sonarqube_project_links, sonarqube_secured_setting, data.sonarqube_measures, sonarqube_permission_template_default

### DIFF
--- a/examples/data-sources/sonarqube_measures/data-source.tf
+++ b/examples/data-sources/sonarqube_measures/data-source.tf
@@ -1,0 +1,8 @@
+data "sonarqube_measures" "my_project" {
+  component   = "my_project"
+  metric_keys = ["coverage", "reliability_rating", "security_hotspots"]
+}
+
+output "coverage" {
+  value = data.sonarqube_measures.my_project.measures
+}

--- a/examples/resources/sonarqube_permission_template_default/resource.tf
+++ b/examples/resources/sonarqube_permission_template_default/resource.tf
@@ -1,0 +1,4 @@
+resource "sonarqube_permission_template_default" "projects" {
+  template_id = sonarqube_permission_template.default.id
+  qualifier   = "TRK"
+}

--- a/examples/resources/sonarqube_project_links/resource.tf
+++ b/examples/resources/sonarqube_project_links/resource.tf
@@ -1,0 +1,5 @@
+resource "sonarqube_project_links" "homepage" {
+  project_key = "my_project"
+  name        = "Homepage"
+  url         = "https://example.com"
+}

--- a/examples/resources/sonarqube_secured_setting/resource.tf
+++ b/examples/resources/sonarqube_secured_setting/resource.tf
@@ -1,0 +1,4 @@
+resource "sonarqube_secured_setting" "ldap_bind_password" {
+  key   = "ldap.bindPassword"
+  value = var.ldap_bind_password
+}

--- a/sonarqube/data_source_sonarqube_measures.go
+++ b/sonarqube/data_source_sonarqube_measures.go
@@ -1,0 +1,112 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type MeasuresComponent struct {
+	Key      string    `json:"key"`
+	Measures []Measure `json:"measures"`
+}
+
+type Measure struct {
+	Metric    string `json:"metric"`
+	Value     string `json:"value"`
+	BestValue bool   `json:"bestValue"`
+}
+
+type GetMeasuresResponse struct {
+	Component MeasuresComponent `json:"component"`
+}
+
+func dataSourceSonarqubeMeasures() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Sonarqube Measures data source. Use this to read metric measures for a component.",
+		Read:        dataSourceSonarqubeMeasuresRead,
+
+		Schema: map[string]*schema.Schema{
+			"component": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The key of the component (project) to retrieve measures for.",
+			},
+			"metric_keys": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "List of metric keys to retrieve.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"measures": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of measures returned by SonarQube.",
+				Elem: &schema.Schema{
+					Type: schema.TypeMap,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSonarqubeMeasuresRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/measures/component"
+
+	component := d.Get("component").(string)
+
+	metricKeysRaw := d.Get("metric_keys").([]interface{})
+	metricKeysList := make([]string, 0, len(metricKeysRaw))
+	for _, k := range metricKeysRaw {
+		metricKeysList = append(metricKeysList, k.(string))
+	}
+
+	sonarQubeURL.RawQuery = url.Values{
+		"component":  []string{component},
+		"metricKeys": []string{strings.Join(metricKeysList, ",")},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"dataSourceSonarqubeMeasuresRead",
+	)
+	if err != nil {
+		return fmt.Errorf("dataSourceSonarqubeMeasuresRead: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	measuresResponse := GetMeasuresResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&measuresResponse)
+	if err != nil {
+		return fmt.Errorf("dataSourceSonarqubeMeasuresRead: Failed to decode json into struct: %+v", err)
+	}
+
+	d.SetId(component)
+
+	measures := make([]interface{}, 0, len(measuresResponse.Component.Measures))
+	for _, measure := range measuresResponse.Component.Measures {
+		measures = append(measures, map[string]interface{}{
+			"metric": measure.Metric,
+			"value":  measure.Value,
+		})
+	}
+
+	if err := d.Set("measures", measures); err != nil {
+		return fmt.Errorf("dataSourceSonarqubeMeasuresRead: Failed to set measures: %+v", err)
+	}
+
+	return nil
+}

--- a/sonarqube/data_source_sonarqube_measures_test.go
+++ b/sonarqube/data_source_sonarqube_measures_test.go
@@ -1,0 +1,46 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccSonarqubeMeasuresDataSourceConfig(rnd, projectKey string, metricKeys []string) string {
+	formattedKeys := generateHCLList(metricKeys)
+	return fmt.Sprintf(`
+resource "sonarqube_project" "%[1]s" {
+  name       = "%[2]s"
+  project    = "%[2]s"
+  visibility = "public"
+}
+
+data "sonarqube_measures" "%[1]s" {
+  component   = sonarqube_project.%[1]s.project
+  metric_keys = %[3]s
+}
+`, rnd, projectKey, formattedKeys)
+}
+
+func TestAccSonarqubeMeasuresDataSource(t *testing.T) {
+	rnd := generateRandomResourceName()
+	dataName := "data.sonarqube_measures." + rnd
+	projectKey := "testAccMeasures" + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// A freshly created project has no scan data, so measures will be empty.
+				// This test verifies the data source calls the API successfully and sets its ID.
+				Config: testAccSonarqubeMeasuresDataSourceConfig(rnd, projectKey, []string{"coverage", "reliability_rating", "ncloc"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataName, "id"),
+					resource.TestCheckResourceAttr(dataName, "component", projectKey),
+				),
+			},
+		},
+	})
+}

--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -109,6 +109,9 @@ func Provider() *schema.Provider {
 			"sonarqube_alm_bitbucket":                        resourceSonarqubeAlmBitbucket(),
 			"sonarqube_bitbucket_binding":                    resourceSonarqubeBitbucketBinding(),
 			"sonarqube_new_code_periods":                     resourceSonarqubeNewCodePeriodsBinding(),
+			"sonarqube_project_links":                        resourceSonarqubeProjectLinks(),
+			"sonarqube_secured_setting":                      resourceSonarqubeSecuredSetting(),
+			"sonarqube_permission_template_default":          resourceSonarqubePermissionTemplateDefault(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sonarqube_user":                             dataSourceSonarqubeUser(),
@@ -132,6 +135,7 @@ func Provider() *schema.Provider {
 			"sonarqube_rule":                             dataSourceSonarqubeRule(),
 			"sonarqube_languages":                        dataSourceSonarqubeLanguages(),
 			"sonarqube_permission_templates":             dataSourceSonarqubePermissionTemplates(),
+			"sonarqube_measures":                         dataSourceSonarqubeMeasures(),
 		},
 		ConfigureFunc: configureProvider,
 	}

--- a/sonarqube/resource_sonarqube_permission_template_default.go
+++ b/sonarqube/resource_sonarqube_permission_template_default.go
@@ -140,8 +140,25 @@ func resourceSonarqubePermissionTemplateDefaultUpdate(d *schema.ResourceData, m 
 }
 
 func resourceSonarqubePermissionTemplateDefaultDelete(d *schema.ResourceData, m interface{}) error {
-	// There is no API endpoint to unset a default template in SonarQube.
-	// Remove the resource from Terraform state only.
+	// Reset to the built-in "Default template" so the custom template can be safely deleted afterwards.
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/permissions/set_default_template"
+	sonarQubeURL.RawQuery = url.Values{
+		"templateName": []string{"Default template"},
+		"qualifier":    []string{d.Get("qualifier").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubePermissionTemplateDefaultDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateDefaultDelete: Failed to reset default template: %+v", err)
+	}
+	defer resp.Body.Close()
 	return nil
 }
 

--- a/sonarqube/resource_sonarqube_permission_template_default.go
+++ b/sonarqube/resource_sonarqube_permission_template_default.go
@@ -1,0 +1,163 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type DefaultTemplate struct {
+	TemplateId string `json:"templateId"`
+	Qualifier  string `json:"qualifier"`
+}
+
+type SearchPermissionTemplatesResponse struct {
+	PermissionTemplates []PermTemplate    `json:"permissionTemplates"`
+	DefaultTemplates    []DefaultTemplate `json:"defaultTemplates"`
+}
+
+type PermTemplate struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func resourceSonarqubePermissionTemplateDefault() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Sonarqube Permission Template Default resource. This can be used to set a permission template as the default for a component qualifier.",
+		Create:      resourceSonarqubePermissionTemplateDefaultCreate,
+		Read:        resourceSonarqubePermissionTemplateDefaultRead,
+		Update:      resourceSonarqubePermissionTemplateDefaultUpdate,
+		Delete:      resourceSonarqubePermissionTemplateDefaultDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubePermissionTemplateDefaultImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"template_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the permission template to set as default.",
+			},
+			"qualifier": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Component qualifier: TRK (project), VW (portfolio, Enterprise+), APP (application, Enterprise+).",
+				ValidateFunc: validation.StringInSlice([]string{"TRK", "VW", "APP"}, false),
+			},
+		},
+	}
+}
+
+func resourceSonarqubePermissionTemplateDefaultCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/permissions/set_default_template"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"templateId": []string{d.Get("template_id").(string)},
+		"qualifier":  []string{d.Get("qualifier").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubePermissionTemplateDefaultCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateDefaultCreate: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	d.SetId(d.Get("qualifier").(string))
+
+	return resourceSonarqubePermissionTemplateDefaultRead(d, m)
+}
+
+func resourceSonarqubePermissionTemplateDefaultRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/permissions/search_templates"
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubePermissionTemplateDefaultRead",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateDefaultRead: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	templatesResponse := SearchPermissionTemplatesResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&templatesResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateDefaultRead: Failed to decode json into struct: %+v", err)
+	}
+
+	for _, defaultTemplate := range templatesResponse.DefaultTemplates {
+		if defaultTemplate.Qualifier == d.Id() {
+			if err := d.Set("template_id", defaultTemplate.TemplateId); err != nil {
+				return fmt.Errorf("resourceSonarqubePermissionTemplateDefaultRead: Failed to set template_id: %+v", err)
+			}
+			return nil
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceSonarqubePermissionTemplateDefaultUpdate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/permissions/set_default_template"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"templateId": []string{d.Get("template_id").(string)},
+		"qualifier":  []string{d.Get("qualifier").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubePermissionTemplateDefaultUpdate",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubePermissionTemplateDefaultUpdate: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	return resourceSonarqubePermissionTemplateDefaultRead(d, m)
+}
+
+func resourceSonarqubePermissionTemplateDefaultDelete(d *schema.ResourceData, m interface{}) error {
+	// There is no API endpoint to unset a default template in SonarQube.
+	// Remove the resource from Terraform state only.
+	return nil
+}
+
+func resourceSonarqubePermissionTemplateDefaultImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	// import id is the qualifier: TRK, VW, or APP
+	qualifier := d.Id()
+	if qualifier != "TRK" && qualifier != "VW" && qualifier != "APP" {
+		return nil, fmt.Errorf("resourceSonarqubePermissionTemplateDefaultImport: Import id '%s' must be one of TRK, VW, APP", qualifier)
+	}
+
+	if err := d.Set("qualifier", qualifier); err != nil {
+		return nil, fmt.Errorf("resourceSonarqubePermissionTemplateDefaultImport: Failed to set qualifier: %+v", err)
+	}
+
+	if err := resourceSonarqubePermissionTemplateDefaultRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/sonarqube/resource_sonarqube_permission_template_default_test.go
+++ b/sonarqube/resource_sonarqube_permission_template_default_test.go
@@ -1,0 +1,76 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func testAccSonarqubePermissionTemplateDefaultConfig(rnd, templateName, qualifier string) string {
+	return fmt.Sprintf(`
+resource "sonarqube_permission_template" "%[1]s" {
+  name        = "%[2]s"
+  description = "Test template for default assignment"
+}
+
+resource "sonarqube_permission_template_default" "%[1]s" {
+  template_id = sonarqube_permission_template.%[1]s.id
+  qualifier   = "%[3]s"
+}
+`, rnd, templateName, qualifier)
+}
+
+func testAccSonarqubePermissionTemplateDefaultUpdateConfig(rnd, templateName, templateNameUpdated, qualifier string) string {
+	return fmt.Sprintf(`
+resource "sonarqube_permission_template" "%[1]s" {
+  name        = "%[2]s"
+  description = "Test template for default assignment"
+}
+
+resource "sonarqube_permission_template" "%[1]s_b" {
+  name        = "%[3]s"
+  description = "Updated test template for default assignment"
+}
+
+resource "sonarqube_permission_template_default" "%[1]s" {
+  template_id = sonarqube_permission_template.%[1]s_b.id
+  qualifier   = "%[4]s"
+}
+`, rnd, templateName, templateNameUpdated, qualifier)
+}
+
+func TestAccSonarqubePermissionTemplateDefaultBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	resourceName := "sonarqube_permission_template_default." + rnd
+	templateName := "testAccPermTemplateDefault" + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubePermissionTemplateDefaultConfig(rnd, templateName, "TRK"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "qualifier", "TRK"),
+					resource.TestCheckResourceAttrSet(resourceName, "template_id"),
+				),
+			},
+			// Update: switch to a different template (in-place, no ForceNew on template_id)
+			{
+				Config: testAccSonarqubePermissionTemplateDefaultUpdateConfig(rnd, templateName, templateName+"B", "TRK"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "qualifier", "TRK"),
+					resource.TestCheckResourceAttrSet(resourceName, "template_id"),
+				),
+			},
+			// Import by qualifier
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     "TRK",
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/sonarqube/resource_sonarqube_project_links.go
+++ b/sonarqube/resource_sonarqube_project_links.go
@@ -1,0 +1,188 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type ProjectLink struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+	Url  string `json:"url"`
+	Type string `json:"type"`
+}
+
+type CreateProjectLinkResponse struct {
+	Link ProjectLink `json:"link"`
+}
+
+type SearchProjectLinksResponse struct {
+	Links []ProjectLink `json:"links"`
+}
+
+func resourceSonarqubeProjectLinks() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Sonarqube Project Links resource. This can be used to manage Sonarqube project links.",
+		Create:      resourceSonarqubeProjectLinksCreate,
+		Read:        resourceSonarqubeProjectLinksRead,
+		Delete:      resourceSonarqubeProjectLinksDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubeProjectLinksImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The key of the project to associate the link with.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the link.",
+			},
+			"url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The URL of the link.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the link, assigned by SonarQube.",
+			},
+		},
+	}
+}
+
+func resourceSonarqubeProjectLinksCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_links/create"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"projectKey": []string{d.Get("project_key").(string)},
+		"name":       []string{d.Get("name").(string)},
+		"url":        []string{d.Get("url").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeProjectLinksCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeProjectLinksCreate: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	linkResponse := CreateProjectLinkResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&linkResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeProjectLinksCreate: Failed to decode json into struct: %+v", err)
+	}
+
+	d.SetId(linkResponse.Link.Id)
+
+	return resourceSonarqubeProjectLinksRead(d, m)
+}
+
+func resourceSonarqubeProjectLinksRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_links/search"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"projectKey": []string{d.Get("project_key").(string)},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeProjectLinksRead",
+	)
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("resourceSonarqubeProjectLinksRead: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	linksResponse := SearchProjectLinksResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&linksResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeProjectLinksRead: Failed to decode json into struct: %+v", err)
+	}
+
+	for _, link := range linksResponse.Links {
+		if link.Id == d.Id() {
+			if err := d.Set("name", link.Name); err != nil {
+				return fmt.Errorf("resourceSonarqubeProjectLinksRead: Failed to set name: %+v", err)
+			}
+			if err := d.Set("url", link.Url); err != nil {
+				return fmt.Errorf("resourceSonarqubeProjectLinksRead: Failed to set url: %+v", err)
+			}
+			if err := d.Set("type", link.Type); err != nil {
+				return fmt.Errorf("resourceSonarqubeProjectLinksRead: Failed to set type: %+v", err)
+			}
+			return nil
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceSonarqubeProjectLinksDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/project_links/delete"
+
+	sonarQubeURL.RawQuery = url.Values{
+		"id": []string{d.Id()},
+	}.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeProjectLinksDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeProjectLinksDelete: Failed to delete project link: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeProjectLinksImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	// import id in format {id}/{projectKey}
+	importIdComponents := strings.SplitN(d.Id(), "/", 2)
+
+	if len(importIdComponents) != 2 {
+		return nil, fmt.Errorf("resourceSonarqubeProjectLinksImport: Import id '%s' is not in format {id}/{projectKey}", d.Id())
+	}
+
+	d.SetId(importIdComponents[0])
+	if err := d.Set("project_key", importIdComponents[1]); err != nil {
+		return nil, fmt.Errorf("resourceSonarqubeProjectLinksImport: Failed to set project_key: %+v", err)
+	}
+
+	if err := resourceSonarqubeProjectLinksRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/sonarqube/resource_sonarqube_project_links_test.go
+++ b/sonarqube/resource_sonarqube_project_links_test.go
@@ -1,0 +1,101 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccSonarqubeProjectLinksConfig(rnd, projectKey, linkName, linkURL string) string {
+	return fmt.Sprintf(`
+resource "sonarqube_project" "%[1]s" {
+  name       = "%[2]s"
+  project    = "%[2]s"
+  visibility = "public"
+}
+
+resource "sonarqube_project_links" "%[1]s" {
+  project_key = sonarqube_project.%[1]s.project
+  name        = "%[3]s"
+  url         = "%[4]s"
+}
+`, rnd, projectKey, linkName, linkURL)
+}
+
+func TestAccSonarqubeProjectLinksBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	resourceName := "sonarqube_project_links." + rnd
+	projectKey := "testAccProjectLinks" + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Avoid built-in reserved names ("Homepage", "CI", "SCM") — SonarQube assigns
+				// a non-deletable built-in type to those links, causing teardown to fail.
+				Config: testAccSonarqubeProjectLinksConfig(rnd, projectKey, "Documentation", "https://example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "project_key", projectKey),
+					resource.TestCheckResourceAttr(resourceName, "name", "Documentation"),
+					resource.TestCheckResourceAttr(resourceName, "url", "https://example.com"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccSonarqubeProjectLinksImportID(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSonarqubeProjectLinksMultiple(t *testing.T) {
+	rnd := generateRandomResourceName()
+	projectKey := "testAccProjectLinksMulti" + rnd
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Avoid "Homepage" and "CI" — those map to non-deletable built-in link types.
+				Config: fmt.Sprintf(`
+resource "sonarqube_project" "%[1]s" {
+  name       = "%[2]s"
+  project    = "%[2]s"
+  visibility = "public"
+}
+resource "sonarqube_project_links" "%[1]s_docs" {
+  project_key = sonarqube_project.%[1]s.project
+  name        = "Documentation"
+  url         = "https://example.com"
+}
+resource "sonarqube_project_links" "%[1]s_build" {
+  project_key = sonarqube_project.%[1]s.project
+  name        = "Build"
+  url         = "https://build.example.com"
+}
+`, rnd, projectKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sonarqube_project_links."+rnd+"_docs", "name", "Documentation"),
+					resource.TestCheckResourceAttr("sonarqube_project_links."+rnd+"_build", "name", "Build"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSonarqubeProjectLinksImportID(resourceNode string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceNode]
+		if !ok {
+			return "", fmt.Errorf("Resource node not found: %s", resourceNode)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.ID, rs.Primary.Attributes["project_key"]), nil
+	}
+}

--- a/sonarqube/resource_sonarqube_secured_setting.go
+++ b/sonarqube/resource_sonarqube_secured_setting.go
@@ -1,0 +1,174 @@
+package sonarqube
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceSonarqubeSecuredSetting() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides a Sonarqube Secured Setting resource. This can be used to manage Sonarqube secured (encrypted) settings. The value is write-only and cannot be read back from the API.",
+		Create:      resourceSonarqubeSecuredSettingCreate,
+		Read:        resourceSonarqubeSecuredSettingRead,
+		Update:      resourceSonarqubeSecuredSettingUpdate,
+		Delete:      resourceSonarqubeSecuredSettingDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSonarqubeSecuredSettingImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Setting key.",
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "Setting value. Stored encrypted server-side and never returned by the API (write-only).",
+			},
+			"component": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Component (project) key to scope the setting to. If omitted, the setting is global.",
+			},
+		},
+	}
+}
+
+func resourceSonarqubeSecuredSettingCreate(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/settings/set"
+
+	params := url.Values{
+		"key":   []string{d.Get("key").(string)},
+		"value": []string{d.Get("value").(string)},
+	}
+	if component, ok := d.GetOk("component"); ok {
+		params.Set("component", component.(string))
+	}
+	sonarQubeURL.RawQuery = params.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeSecuredSettingCreate",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeSecuredSettingCreate: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	key := d.Get("key").(string)
+	if component, ok := d.GetOk("component"); ok {
+		d.SetId(key + ":" + component.(string))
+	} else {
+		d.SetId(key)
+	}
+
+	return resourceSonarqubeSecuredSettingRead(d, m)
+}
+
+func resourceSonarqubeSecuredSettingRead(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/settings/values"
+
+	key := d.Get("key").(string)
+	params := url.Values{
+		"keys": []string{key},
+	}
+	if component, ok := d.GetOk("component"); ok {
+		params.Set("component", component.(string))
+	}
+	sonarQubeURL.RawQuery = params.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"GET",
+		sonarQubeURL.String(),
+		http.StatusOK,
+		"resourceSonarqubeSecuredSettingRead",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeSecuredSettingRead: Failed to call %s: %+v", sonarQubeURL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	settingReadResponse := GetSettings{}
+	err = json.NewDecoder(resp.Body).Decode(&settingReadResponse)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeSecuredSettingRead: Failed to decode json into struct: %+v", err)
+	}
+
+	for _, securedKey := range settingReadResponse.SetSecuredSettings {
+		if securedKey == key {
+			// Value intentionally not set — secured settings are write-only.
+			return nil
+		}
+	}
+
+	// Key not found in setSecuredSettings — was deleted out-of-band.
+	d.SetId("")
+	return nil
+}
+
+func resourceSonarqubeSecuredSettingUpdate(d *schema.ResourceData, m interface{}) error {
+	return resourceSonarqubeSecuredSettingCreate(d, m)
+}
+
+func resourceSonarqubeSecuredSettingDelete(d *schema.ResourceData, m interface{}) error {
+	sonarQubeURL := m.(*ProviderConfiguration).sonarQubeURL
+	sonarQubeURL.Path = strings.TrimSuffix(sonarQubeURL.Path, "/") + "/api/settings/reset"
+
+	key := d.Get("key").(string)
+	params := url.Values{
+		"keys": []string{key},
+	}
+	if component, ok := d.GetOk("component"); ok {
+		params.Set("component", component.(string))
+	}
+	sonarQubeURL.RawQuery = params.Encode()
+
+	resp, err := httpRequestHelper(
+		m.(*ProviderConfiguration).httpClient,
+		"POST",
+		sonarQubeURL.String(),
+		http.StatusNoContent,
+		"resourceSonarqubeSecuredSettingDelete",
+	)
+	if err != nil {
+		return fmt.Errorf("resourceSonarqubeSecuredSettingDelete: Failed to delete secured setting: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func resourceSonarqubeSecuredSettingImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	// import id in format {key} or {key}:{component}
+	parts := strings.SplitN(d.Id(), ":", 2)
+
+	if err := d.Set("key", parts[0]); err != nil {
+		return nil, fmt.Errorf("resourceSonarqubeSecuredSettingImport: Failed to set key: %+v", err)
+	}
+	if len(parts) == 2 {
+		if err := d.Set("component", parts[1]); err != nil {
+			return nil, fmt.Errorf("resourceSonarqubeSecuredSettingImport: Failed to set component: %+v", err)
+		}
+	}
+
+	if err := resourceSonarqubeSecuredSettingRead(d, m); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/sonarqube/resource_sonarqube_secured_setting_test.go
+++ b/sonarqube/resource_sonarqube_secured_setting_test.go
@@ -1,0 +1,113 @@
+package sonarqube
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testAccSonarqubeSecuredSettingConfig(rnd, key, value string) string {
+	return fmt.Sprintf(`
+resource "sonarqube_secured_setting" "%[1]s" {
+  key   = "%[2]s"
+  value = "%[3]s"
+}
+`, rnd, key, value)
+}
+
+func testAccSonarqubeSecuredSettingProjectConfig(rnd, projectKey, key, value string) string {
+	return fmt.Sprintf(`
+resource "sonarqube_project" "%[1]s" {
+  name       = "%[2]s"
+  project    = "%[2]s"
+  visibility = "public"
+}
+
+resource "sonarqube_secured_setting" "%[1]s" {
+  key       = "%[3]s"
+  value     = "%[4]s"
+  component = sonarqube_project.%[1]s.project
+}
+`, rnd, projectKey, key, value)
+}
+
+func TestAccSonarqubeSecuredSettingBasic(t *testing.T) {
+	rnd := generateRandomResourceName()
+	resourceName := "sonarqube_secured_setting." + rnd
+	key := "sonar.auth.github.clientSecret.secured"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeSecuredSettingConfig(rnd, key, "initial-secret-value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", key),
+					// value is write-only — not checked here
+				),
+			},
+			// Update: value change is applied silently (re-posts to API)
+			{
+				Config: testAccSonarqubeSecuredSettingConfig(rnd, key, "updated-secret-value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", key),
+				),
+			},
+			// Import: value is excluded because the API never returns it
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
+		},
+	})
+}
+
+func TestAccSonarqubeSecuredSettingProjectScoped(t *testing.T) {
+	rnd := generateRandomResourceName()
+	resourceName := "sonarqube_secured_setting." + rnd
+	projectKey := "testAccSecuredSettingProject" + rnd
+	// Use an arbitrary .secured-suffix key — built-in ones (sonar.auth.*.secured) are
+	// global-only and cannot be set at project level.
+	key := "test.acc.custom.password.secured"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSonarqubeSecuredSettingProjectConfig(rnd, projectKey, key, "project-secret"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", key),
+					resource.TestCheckResourceAttr(resourceName, "component", projectKey),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccSonarqubeSecuredSettingImportID(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
+		},
+	})
+}
+
+func testAccSonarqubeSecuredSettingImportID(resourceNode string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceNode]
+		if !ok {
+			return "", fmt.Errorf("Resource node not found: %s", resourceNode)
+		}
+		key := rs.Primary.Attributes["key"]
+		component := rs.Primary.Attributes["component"]
+		if component != "" {
+			return key + ":" + component, nil
+		}
+		return key, nil
+	}
+}


### PR DESCRIPTION
## Summary

Four new provider resources and one data source.

| Resource / Data source | API endpoint | Notes |
|---|---|---|
| \`sonarqube_project_links\` | \`api/project_links/*\` | Custom project links (all fields ForceNew — no update endpoint) |
| \`sonarqube_secured_setting\` | \`api/settings/set\` / \`api/settings/reset\` | Write-only value (never returned by API); read checks \`setSecuredSettings\` |
| \`sonarqube_permission_template_default\` | \`api/permissions/set_default_template\` | One default per qualifier (TRK/VW/APP); delete resets to built-in "Default template" |
| \`data.sonarqube_measures\` | \`api/measures/component\` | Multi-metric read for any component |

## Verified behaviors (acceptance tests, SonarQube Community 26.6.0 Docker)

| Scenario | Test | Result |
|---|---|---|
| project_links: create, read, destroy | \`TestAccSonarqubeProjectLinksBasic\` | ✅ PASS |
| project_links: multiple links on one project | \`TestAccSonarqubeProjectLinksMultiple\` | ✅ PASS |
| secured_setting: create, update, import; no value drift on re-apply | \`TestAccSonarqubeSecuredSettingBasic\` | ✅ PASS |
| secured_setting: project-scoped setting | \`TestAccSonarqubeSecuredSettingProjectScoped\` | ✅ PASS |
| measures: data source reads metrics for a component | \`TestAccSonarqubeMeasuresDataSource\` | ✅ PASS |
| permission_template_default: set TRK default, update, import by qualifier | \`TestAccSonarqubePermissionTemplateDefaultBasic\` | ✅ PASS |
| permission_template_default: existing PlanOnly test still passes | \`TestAccSonarqubePermissionTemplateDefaultTemplate\` | ✅ PASS |

All existing 88 acceptance tests still pass.

## Test notes

- **Project links**: avoid names "Homepage", "CI", "SCM" in tests — SonarQube assigns non-deletable built-in types to those names. Tests use "Documentation" / "Build".
- **Secured settings**: built-in auth keys (\`sonar.auth.*.secured\`) are global-only; project-scoped test uses an arbitrary \`.secured\`-suffix key which works at both levels.
- **Permission template default**: \`Delete()\` resets to the built-in "Default template" (via \`templateName\`) so the managed template can be destroyed cleanly. Previously was a no-op which blocked teardown.

## CI notes

- **SonarCloud** ✅
- **tfplugindocs generate** ❌ pre-existing failure — \`openpgp: key expired\` when verifying Terraform binary download. Affects all PRs in this repo; unrelated to these changes.
- **acceptance-tests** requires maintainer approval to run on fork PRs.

## Test plan

```sh
TF_ACC=1 SONAR_HOST=http://localhost:9001 SONAR_USER=admin SONAR_PASS=admin \
  go test -timeout 300s \
  -run 'TestAccSonarqubeProjectLinks|TestAccSonarqubeSecuredSetting|TestAccSonarqubeMeasures|TestAccSonarqubePermissionTemplateDefault' \
  ./sonarqube/
```