### PR TITLE
fix: detect SonarQube version from DCE application nodes

### DIFF
--- a/sonarqube/provider.go
+++ b/sonarqube/provider.go
@@ -247,6 +247,10 @@ func sonarqubeSystemInfo(client *retryablehttp.Client, sonarqube url.URL) (strin
 	}
 
 	sonarqubeVersion := gjson.GetBytes(responseData, "System.Version").String()
+	// In DCE, version is not at System.Version but in each application node
+	if sonarqubeVersion == "" {
+		sonarqubeVersion = gjson.GetBytes(responseData, "Application Nodes.0.System.Version").String()
+	}
 	sonarqubeEdition := gjson.GetBytes(responseData, "System.Edition").String()
 	return sonarqubeVersion, sonarqubeEdition, nil
 }


### PR DESCRIPTION
## Problem
SonarQube Data Center Edition (DCE) returns a different `/api/system/info` response structure than Community/Developer/Enterprise editions. In non-DCE editions, the version is at `System.Version` in the response root. In DCE, `System.Version` is absent — version is instead nested under each application node at `Application Nodes[N].System.Version`.

The `sonarqubeSystemInfo` was only reading `System.Version`, which returns an empty string for DCE installations, causing `version.NewVersion("")` to fail with: Error: failed to convert sonarqube version to a version: malformed version:

## Fix

Fall back to `Application Nodes.0.System.Version` when `System.Version` is empty. All nodes in a DCE cluster run the same version (a mixed-version cluster cannot form), so using the first node is safe.