### PR TITLE
ci: install terraform before tfplugindocs to avoid expired PGP key

### DIFF
--- a/.github/workflows/tfplugindocs-check.yml
+++ b/.github/workflows/tfplugindocs-check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix/tfplugindocs-terraform-on-path
   
 jobs:
   tfplugindocs_check:

--- a/.github/workflows/tfplugindocs-check.yml
+++ b/.github/workflows/tfplugindocs-check.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix/tfplugindocs-terraform-on-path
   
 jobs:
   tfplugindocs_check:

--- a/.github/workflows/tfplugindocs-check.yml
+++ b/.github/workflows/tfplugindocs-check.yml
@@ -17,8 +17,6 @@ jobs:
           go-version-file: tools/go.mod
           cache-dependency-path: tools/go.sum
 
-      # tfplugindocs uses the terraform binary from PATH; without it, it downloads
-      # one and verifies the signature against an expired HashiCorp PGP key.
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false

--- a/.github/workflows/tfplugindocs-check.yml
+++ b/.github/workflows/tfplugindocs-check.yml
@@ -17,6 +17,12 @@ jobs:
           go-version-file: tools/go.mod
           cache-dependency-path: tools/go.sum
 
+      # tfplugindocs uses the terraform binary from PATH; without it, it downloads
+      # one and verifies the signature against an expired HashiCorp PGP key.
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
       - run: |
           make tools
           make docs

--- a/.github/workflows/tfplugindocs-check.yml
+++ b/.github/workflows/tfplugindocs-check.yml
@@ -19,7 +19,7 @@ jobs:
 
       # tfplugindocs uses the terraform binary from PATH; without it, it downloads
       # one and verifies the signature against an expired HashiCorp PGP key.
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/tfplugindocs-generate.yml
+++ b/.github/workflows/tfplugindocs-generate.yml
@@ -29,6 +29,13 @@ jobs:
           go-version-file: tools/go.mod
           cache-dependency-path: tools/go.sum
 
+      # tfplugindocs uses the terraform binary from PATH; without it, it downloads
+      # one and verifies the signature against an expired HashiCorp PGP key.
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
       - name: Install tools and generate documentation
         run: |
           make tools

--- a/.github/workflows/tfplugindocs-generate.yml
+++ b/.github/workflows/tfplugindocs-generate.yml
@@ -32,7 +32,7 @@ jobs:
       # tfplugindocs uses the terraform binary from PATH; without it, it downloads
       # one and verifies the signature against an expired HashiCorp PGP key.
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/tfplugindocs-generate.yml
+++ b/.github/workflows/tfplugindocs-generate.yml
@@ -29,8 +29,6 @@ jobs:
           go-version-file: tools/go.mod
           cache-dependency-path: tools/go.sum
 
-      # tfplugindocs uses the terraform binary from PATH; without it, it downloads
-      # one and verifies the signature against an expired HashiCorp PGP key.
       - name: Setup terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:


### PR DESCRIPTION
## Problem

Both docs workflows fail with:

```
unable to download Terraform binary: unable to verify checksums signature: openpgp: key expired
```

`tfplugindocs` resolves the terraform binary from `PATH`, and falls back to downloading one — verifying it against a HashiCorp PGP key bundled in `hc-install v0.9.0`. That key has since expired, so the fallback always fails on a runner with no terraform installed.

This is a repo-wide breakage, not PR-specific: `tfplugindocs check` on `master` went from success (2026-04-01) to failure (2026-05-02) with no relevant code change in between.

## Root cause, reproduced locally

Using the pinned `tfplugindocs v0.20.1`:

| Condition | Result |
|---|---|
| terraform on `PATH` | exit 0, zero doc diff |
| terraform absent from `PATH` | `openpgp: key expired` — identical to CI |

So the failure is entirely in the download-and-verify fallback path. No dependency bump is needed.

## Fix

Add the `hashicorp/setup-terraform@v3` step that [`acceptance-tests.yml`](.github/workflows/acceptance-tests.yml) already uses, to both docs workflows. With terraform on `PATH`, the signed-download path is never taken.

`terraform_wrapper: false` matches the existing usage — the wrapper script wraps stdout and breaks `terraform-exec` output parsing.

13 added lines, two files, no dependency changes.

## Note on verifying this

`tfplugindocs-generate.yml` uses `pull_request_target`, which runs the workflow definition from the **base** branch. So this PR will still show the old failure until the change is on `master` — that is expected and not a sign the fix is wrong. The mechanism is proven by the local reproduction above.